### PR TITLE
fix(scalingo): le Procfile ne demarrait pas le serveur

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: deno serve --allow-net --allow-env --allow-read --port $PORT src/main.ts
+web: deno run --allow-net --allow-env=FGP_SALT,PORT,SCALINGO_API_URL,SCALINGO_AUTH_URL,FGP_LOGS_ENABLED,FGP_LOGS_BUFFER_NETWORK,FGP_LOGS_BUFFER_DETAILED,FGP_LOGS_INACTIVITY_MIN,FGP_LOGS_DETAILED_MAX_KB --allow-read=static src/main.ts

--- a/docs/scalingo-deploy.md
+++ b/docs/scalingo-deploy.md
@@ -4,7 +4,7 @@ Guide de deploiement de Fine-Grained Proxy sur [Scalingo](https://scalingo.com/)
 
 ## TL;DR
 
-Scalingo ne supporte pas Deno nativement. La solution retenue est le buildpack [`betagouv/deno-buildpack`](https://github.com/betagouv/deno-buildpack), compatible Scalingo. Il installe Deno, cache les deps, et **execute automatiquement `deno task build`** si une task `build` existe dans `deno.json` — ce qui compile les assets CSS + client JS pendant la phase de build du slug, avant le demarrage du dyno.
+Scalingo ne supporte pas Deno nativement. La solution retenue est le buildpack [`betagouv/deno-buildpack`](https://github.com/betagouv/deno-buildpack), compatible Scalingo. Il installe Deno, cache les deps, et **execute automatiquement `deno task build`** si une task `build` existe dans `deno.json`, ce qui compile les assets CSS et client JS pendant la phase de build du slug, avant le demarrage du dyno.
 
 ## Etape par etape
 
@@ -20,7 +20,7 @@ scalingo create fgp-proxy
 scalingo --app fgp-proxy env-set BUILDPACK_URL=https://github.com/betagouv/deno-buildpack.git
 ```
 
-Le buildpack detecte automatiquement le projet via `deno.json` (affiche "Deno" + exit 0, compatible Scalingo). Pendant le build, il detecte la task `build` dans `deno.json` et execute `deno task build` — CSS, client JS, version et changelog sont compiles dans `static/` avant le demarrage du dyno. `static/` et `src/ui/changelog-data.ts` etant gitignores, ce build au deploy est indispensable.
+Le buildpack detecte automatiquement le projet via `deno.json` (affiche "Deno" + exit 0, compatible Scalingo). Pendant le build, il detecte la task `build` dans `deno.json` et execute `deno task build` : CSS, client JS, version et changelog sont compiles dans `static/` avant le demarrage du dyno. `static/` et `src/ui/changelog-data.ts` etant gitignores, ce build au deploy est indispensable.
 
 Si besoin, la commande de build peut etre surchargee via la variable d'environnement `DENO_BUILD_CMD`.
 
@@ -29,10 +29,12 @@ Si besoin, la commande de build peut etre surchargee via la variable d'environne
 Le `Procfile` a la racine du repo :
 
 ```
-web: deno serve --allow-net --allow-env --allow-read --port $PORT src/main.ts
+web: deno run --allow-net --allow-env=FGP_SALT,PORT,SCALINGO_API_URL,SCALINGO_AUTH_URL,FGP_LOGS_ENABLED,FGP_LOGS_BUFFER_NETWORK,FGP_LOGS_BUFFER_DETAILED,FGP_LOGS_INACTIVITY_MIN,FGP_LOGS_DETAILED_MAX_KB --allow-read=static src/main.ts
 ```
 
-`--port $PORT` est obligatoire. `deno serve` ne lit pas la variable d'environnement `PORT` automatiquement — sans ce flag, le serveur binde sur 8000 et Scalingo echoue le health check TCP.
+`deno run` et non `deno serve` : `src/main.ts` appelle `Deno.serve()` sous `import.meta.main` et n'exporte plus `default { fetch }`. Sous `deno serve`, le module afficherait un avertissement et sortirait en code 0, donc le dyno ne demarrerait jamais et Scalingo echouerait le health check TCP.
+
+Pas de flag `--port` : `Deno.serve()` lit `PORT` directement. Les permissions sont les memes que celles du `Dockerfile` et de la task `start`, gardez les trois alignees.
 
 ### 4. Configurer les variables d'environnement
 
@@ -90,7 +92,9 @@ curl https://fgp-proxy.osc-fr1.scalingo.io/healthz
 
 ### PORT
 
-Scalingo injecte `PORT` comme variable d'environnement. `deno serve` ne la lit pas automatiquement — le flag `--port $PORT` dans le Procfile est obligatoire. Scalingo verifie que le process ecoute sur `$PORT` via un TCP SYN check au deploiement.
+Scalingo injecte `PORT` comme variable d'environnement. FGP la lit via `Deno.env.get("PORT")` dans l'appel `Deno.serve()` de `src/main.ts`, avec un defaut a 8000. Aucun flag n'est necessaire dans le Procfile. Scalingo verifie que le process ecoute sur `$PORT` via un TCP SYN check au deploiement.
+
+A noter : `deno serve` ignore la variable `PORT` et le champ `port` d'un export par defaut. C'est la raison pour laquelle le point d'entree utilise un `Deno.serve()` explicite.
 
 ### CompressionStream / Web Crypto
 
@@ -100,7 +104,7 @@ Ces APIs sont fournies par le runtime Deno. Tant que le buildpack installe une v
 
 ### Option A : Deployer sur Deno Deploy
 
-C'est la cible naturelle pour FGP (voir [deno-deploy.md](./deno-deploy.md)). Zero config, support natif complet (JSR, Web Crypto, CompressionStream, `deno serve`).
+C'est la cible naturelle pour FGP (voir [deno-deploy.md](./deno-deploy.md)). Zero config, support natif complet (JSR, Web Crypto, CompressionStream, `Deno.serve()`).
 
 ### Option B : Fly.io ou Railway avec Dockerfile
 
@@ -108,7 +112,7 @@ Ces plateformes supportent les Dockerfiles natifs. Le `Dockerfile` existant a la
 
 ### Option C : Committer les assets buildes
 
-Retirer `static/` et `src/ui/changelog-data.ts` du `.gitignore`, builder localement avant chaque push, committer les artifacts. Le Procfile reste `deno serve --port $PORT ...` sans build.
+Retirer `static/` et `src/ui/changelog-data.ts` du `.gitignore`, builder localement avant chaque push, committer les artifacts. Le Procfile reste `deno run ... src/main.ts` sans build.
 
 ## Recommandation
 


### PR DESCRIPTION
Suivi de #1, mergée juste avant. Rien de ce qui suit n'était faux quand cette PR a été écrite en juin : c'est le lot sécurité mergé entre-temps (#2) qui l'a périmée.

## Le bloquant

Le `Procfile` lance `deno serve src/main.ts`. Or `src/main.ts` n'exporte plus `default { fetch }` depuis le passage à un `Deno.serve()` explicite gardé par `import.meta.main`. Sous `deno serve`, un module sans cet export **affiche un avertissement et sort en code 0** : le dyno ne démarre jamais et Scalingo échoue le health check TCP.

C'est exactement le bug qui avait été trouvé dans le `Dockerfile` pendant #2, où le `CMD` ne démarrait rien non plus.

## Ce qui change

Le `Procfile` passe à `deno run`, avec les **mêmes permissions explicites** que le `Dockerfile` et la task `start`, au lieu des `--allow-env` et `--allow-read` ouverts. Le flag `--port $PORT` disparaît, `Deno.serve()` lisant `PORT` directement.

Trois passages de `docs/scalingo-deploy.md` sont réalignés :

- L'affirmation que `--port $PORT` est obligatoire parce que `deno serve` ne lit pas `PORT`. C'était juste, et c'est précisément ce constat qui a mené au correctif de #2, mais le flag n'a plus lieu d'être.
- La section PORT, qui disait que FGP ne lit pas la variable. C'était vrai à l'ouverture de #1 (le champ `port` de l'export par défaut était ignoré sous `deno serve`), c'est faux depuis.
- `deno serve` cité parmi ce que Deno Deploy supporte nativement, remplacé par `Deno.serve()`.

Les deux tirets cadratins réintroduits dans le fichier sont corrigés, le repo était à zéro.

## Vérification

`PORT=9876` avec la commande exacte du Procfile : `/healthz` répond **200 sur 9876**, et 8000 ne répond pas. `deno task verify` passe, 578 tests.

## À valider au premier déploiement réel

Le buildpack exécute `deno task build`, qui inclut `build:version` (appel `git` puis `api.github.com`, avec repli sur `dev` si les deux échouent) et `build:changelog`. Ce chemin n'a jamais été exercé dans un slug Scalingo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Scalingo deployment instructions to use the revised Deno server startup command.
  * Clarified port handling, environment variables, file-access permissions, and deployment configuration.
* **Deployment**
  * Restricted runtime access to approved environment variables and the static directory.
  * Updated the web process configuration to align with the application’s explicit server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->