### PR TITLE
chore(ci): aligne la version Deno de la CI sur celle du Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
 
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
         with:
-          deno-version: "2.9.5"
+          # A garder aligne sur le FROM du Dockerfile : aucun ecosysteme Dependabot
+          # ne suit ce champ, alors qu'il suit l'image. Sans quoi on teste sur une
+          # version et on livre sur une autre.
+          deno-version: "2.9.6"
 
       - name: Install dependencies
         run: deno install --frozen


### PR DESCRIPTION
Suivi direct de #4, qui vient de bumper l'image.

## Le problème

Dependabot suit le `FROM denoland/deno` du Dockerfile, qui est passé à **2.9.6**. Il ne suit en revanche **aucun écosystème** pour le champ `deno-version` de `denoland/setup-deno`, resté à **2.9.5**.

Conséquence : la CI valide sur une version, l'image de production livre sur une autre. C'est le genre d'écart qui ne se voit pas tant qu'un changement de comportement entre deux patchs ne casse quelque chose en production après une CI verte.

## Ce qui change

Le champ passe à 2.9.6, plus un commentaire expliquant la contrainte. Rien dans le fichier ne laissait deviner que ce champ doit être suivi manuellement alors que l'image voisine est automatisée : sans cette note, le prochain bump Dependabot du Dockerfile recréera silencieusement l'écart.

Cette limite avait été anticipée pendant le lot sécurité, au moment du pin initial.

## Test plan

La CI de cette PR s'exécute sur 2.9.6. Si elle passe, l'alignement est validé par construction.
