### PR TITLE
fix(ui): cache-busting des assets et robustesse des hauteurs

### DIFF
--- a/docs/design/ui-feedback-lot-2.md
+++ b/docs/design/ui-feedback-lot-2.md
@@ -1,0 +1,380 @@
+# Design Document : second lot de retours, cause racine commune et gabarit d'alerte
+
+**Branche** : `fix/ui-feedback-mobile-copy`
+**Date** : 2026-09-04
+**Auteur** : Designer FGP
+**Statut** : Draft, prêt à intégrer
+**Portée** : 7 retours de l'architecte sur la page en production, dont 5 partagent une cause racine unique
+**Fichiers impactés (intégration dev)** : `src/ui/config/constants.ts`, `src/ui/config/form-auth.tsx`, `src/ui/config/form-delivery.tsx`, `src/ui/config/form-identity.tsx`, `src/ui/config/form-scopes.tsx`, `src/ui/config/result.tsx`, plus la chaîne de build des assets
+
+> **Inventaire des identifiants : section 6**, qui fait foi comme contrat de sélecteurs. Aucun renommage.
+
+---
+
+## 0. Méthode et mise en garde
+
+Mesures prises dans le navigateur sur la page servie en local, viewport 375 x 812, avec vérification visuelle par capture en plus des hauteurs calculées. Le point 1 a confirmé l'avertissement du lead : **un contrôle peut mesurer exactement la bonne hauteur et paraître faux**, tout dépend de la feuille de style effectivement servie.
+
+Deux pièges de méthode rencontrés, à connaître pour reproduire :
+
+**Chercher une classe à valeur arbitraire dans le CSS compilé demande de tenir compte de l'échappement.** Tailwind écrit `.h-\[2\.375rem\]{height:2.375rem}`. Un `grep '\.h-\[2\.375rem\]'` ne trouve rien et fait croire à tort que la classe est absente. J'ai commis l'erreur avant de la corriger : chercher la valeur brute, `grep '2.375rem'`, est fiable.
+
+**Ajouter une classe Tailwind depuis la console ne prouve rien.** Le JIT ne génère que les classes présentes dans les sources. `self-end` n'étant utilisé nulle part, `classList.add('self-end')` n'a aucun effet et donne un faux négatif. Toutes les expérimentations de ce document utilisent des styles inline ou la suppression de règles via `CSSStyleSheet.deleteRule`.
+
+---
+
+## 1. Points 1 à 5 : une seule cause racine
+
+### 1.1 Les cinq symptômes sont le même défaut
+
+| Point | Symptôme rapporté | Reproduit |
+| --- | --- | --- |
+| 1 | « Charger » fait près du double de la hauteur du champ | oui, 58 px contre 38, ratio 1,53 |
+| 2 | « Base de données » paraît plus petit que les autres | oui, 20,5 px contre 38 |
+| 3 | « Décoder » trop petit en hauteur | oui, 20 px contre 34 |
+| 4 | Dans « Tester un scope », ni les champs ni le bouton à la même taille | oui, champ 34, select 20,5, bouton 20 |
+| 5 | L'icône du bouton oeil touche presque les bords | oui, bouton de 22 px de large pour une icône de 20, soit 1 px de marge |
+
+Sur une feuille de style fraîchement compilée, **aucun des cinq ne se reproduit** : les sept paires sont bien à 0 px d'écart, la mesure du dev était juste. Les cinq apparaissent tous, simultanément et exactement, dès qu'on retire de la feuille de style les quatre règles suivantes :
+
+```
+.h-\[2\.375rem\]   .w-\[2\.375rem\]   .h-\[2\.125rem\]   .items-end
+```
+
+Vérifié par suppression de ces règles à l'exécution, puis mesure et capture. Le rendu obtenu est identique à ce que décrit l'architecte, y compris le « près du double » qui vaut précisément 1,53.
+
+### 1.2 Pourquoi la disparition d'une classe est catastrophique et pas dégradée
+
+C'est mon erreur de conception dans le lot précédent, et je l'assume.
+
+Ma règle disait : « tout bouton adjacent à un champ reçoit la hauteur de l'échelle de son contexte, plus `inline-flex items-center justify-center`, et **perd son `py-*`** ». Retirer le padding vertical supprime la seule source de hauteur intrinsèque du bouton. La géométrie du contrôle repose alors **entièrement** sur une classe unique à valeur arbitraire, sans aucun repli.
+
+Conséquence chiffrée quand cette classe n'est pas appliquée :
+
+| Contrôle | Avec la classe | Sans la classe | Pourquoi |
+| --- | --- | --- | --- |
+| bouton `#btn-addon-load` | 38 px | 20 px, ou **58 px** si le parent n'est pas en `items-end` | plus de padding, donc hauteur du texte seul, ou étirement sur le groupe label plus champ |
+| select `#addon-select` | 38 px | 20,5 px | plus de padding, hauteur de la ligne de texte |
+| bouton `#btn-import-decode` | 34 px | 20 px | idem |
+| select `#test-method` | 34 px | 20,5 px | idem |
+| bouton oeil `#btn-byok-reveal` | 38 x 38 | **22 px de large**, icône de 20 | plus de padding, largeur de l'icône seule |
+
+Le cas du bouton « Charger » cumule les deux défauts : sans `items-end` sur le parent, il retombe sur `align-items: stretch` et **s'étire sur la hauteur du sous-groupe label plus champ**, soit 58 px. C'est très exactement la règle que l'architecte énonce : le bouton prend la hauteur du groupe au lieu de celle du champ.
+
+### 1.3 Pourquoi les classes manquent chez l'utilisateur : le cache navigateur
+
+**Correction de mon diagnostic initial.** J'avais conclu à un `static/` périmé au déploiement. C'est faux, et le lead l'a vérifié en production : `version.txt` renvoie bien le SHA du dernier commit de `main`, la feuille contient `height:2.375rem`, `height:2.125rem` et `align-items:flex-end`, et le bundle porte `data-goto-doc`, `doc-return` et `returnLabel`. Le déploiement est correct.
+
+La vraie cause est le **cache navigateur**. `/static/*` est servi en `max-age=86400` avec des **noms de fichiers stables**. Toute personne ayant ouvert la page dans les 24 heures précédant un déploiement conserve donc l'ancien CSS et l'ancien JS, tout en recevant le nouveau HTML. Elle voit un balisage neuf habillé par une feuille ancienne, ce qui est exactement l'état que je reproduisais en supprimant les quatre règles.
+
+Le raisonnement reliant les six symptômes à une cause unique était juste, y compris pour l'inertie des liens « En savoir plus » qui dépendent de `static/client.js`. Je m'étais seulement trompé de mécanisme : ce n'est pas la production qui sert des assets périmés, c'est le navigateur qui les conserve.
+
+Le correctif de fond est le **cache-busting sur les trois assets**, appliqué par le dev. C'est bien à ce niveau que le problème se règle, pas dans la feuille de style.
+
+**Ce que cela ne change pas** : la fragilité de conception reste entière et le correctif de la section 1.4 reste nécessaire. Un cache-busting empêche la désynchronisation d'arriver, il n'empêche pas une mise en page de s'effondrer quand elle arrive quand même. Toute désynchronisation future entre balisage et feuille de style, quelle qu'en soit la cause, reproduirait les cinq symptômes. Une mise en page qui tombe de 38 à 20 px parce qu'une classe manque est fragile indépendamment de la raison pour laquelle elle manque.
+
+### 1.4 Correctif de conception : défense en profondeur
+
+Indépendamment de la cause de build, **une mise en page ne doit pas s'effondrer parce qu'une classe manque**. Je remplace ma règle du lot précédent par une règle à trois niveaux, où chaque niveau protège le précédent.
+
+**Niveau 1, la hauteur intrinsèque. On garde le `py-*`, on ne le retire plus.** Tout contrôle **dépourvu de bordure visible** reçoit `border border-transparent`, ce qui compense exactement les 2 px de bordure du champ voisin. Cela vaut pour les boutons à fond plein **comme pour les boutons fantômes**, voir la correction en 1.4.1.
+
+La hauteur intrinsèque n'est pas une valeur de padding à recopier, c'est une **soustraction** :
+
+```
+padding vertical = (hauteur d'échelle visée - interligne - 2 px de bordure) / 2
+```
+
+Le padding dépend donc de la taille de police du contrôle, ce que ma règle précédente passait sous silence en écrivant « `py-2` » et « `py-1.5` » comme si l'interligne était constant. Table complète, mesurée sur banc d'essai :
+
+| Échelle | Taille de police | Interligne | Padding vertical | Hauteur obtenue |
+| --- | --- | --- | --- | --- |
+| 38 px | `text-sm` | 20 px | `py-2` | **38** |
+| 38 px | `text-xs` | 16 px | `py-2.5` | **38** |
+| 38 px | icône de 20 px | 20 px | `p-2` | **38** |
+| 34 px | `text-sm` | 20 px | `py-1.5` | **34** |
+| 34 px | `text-xs` | 16 px | `py-2` | **34** |
+| 34 px | icône de 20 px | 20 px | `p-1.5` | **34** |
+
+Contre-exemple mesuré, qui est exactement le piège rencontré : `text-xs` avec `py-2` donne **34 px et non 38**. Un contrôle en `text-xs` à l'échelle 38 réclame `py-2.5`.
+
+**Niveau 2, l'indépendance au contexte flex.** L'alignement se déclare **sur l'élément** avec `self-end`, jamais sur le parent avec `items-end`. Mesuré :
+
+| Recette | Parent `stretch` | Parent `items-start` | Parent `items-center` |
+| --- | --- | --- | --- |
+| padding intrinsèque seul | **58 px**, échec | 38 px | 38 px |
+| padding intrinsèque plus `self-end` | **38 px** | **38 px** | **38 px** |
+
+`self-end` est la pièce porteuse : sans lui, le padding intrinsèque ne suffit pas, l'étirement l'emporte. Avec lui, le bouton fait 38 px et reste aligné sur le bas du champ quel que soit l'alignement du parent. C'est la réponse à la demande « une règle qui ne dépende pas du contexte de flex ».
+
+**Niveau 3, la hauteur explicite.** `CONTROL_H` et `CONTROL_H_SM` sont conservés, mais comme **confirmation** et non plus comme unique source. Si la classe disparaît, les niveaux 1 et 2 tiennent la mise en page.
+
+Recette complète pour un bouton à fond plein, échelle standard :
+
+```jsx
+class={`${CONTROL_H} self-end shrink-0 inline-flex items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium text-white bg-fgp-600 hover:bg-fgp-700 ...`}
+```
+
+Pour un bouton à icône seule, ajouter le pendant horizontal : `w-[2.375rem]` en confirmation, et surtout **`p-2` conservé** pour que l'icône de 20 px garde 8 px de respiration sans dépendre de la largeur imposée.
+
+### 1.5 Inventaire des contrôles à reprendre
+
+Padding déduit de la table du niveau 1 selon la taille de police, jamais recopié d'un contrôle voisin.
+
+| Contrôle | Échelle | Police | Padding | Bordure | Ancrage |
+| --- | --- | --- | --- | --- | --- |
+| `#btn-addon-load` | 38 | `text-sm` | `py-2` | transparente | `self-end` |
+| `#btn-load-apps` | 38 | `text-sm` | `py-2` | transparente | `self-end` |
+| `#addon-select` | 38 | `text-sm` | `py-2` | déjà visible | aucun, il remplit sa colonne |
+| `[data-header-remove]` via `REMOVE_BTN_CLASS` | 38 | icône 20 | `p-2` | **transparente** | `self-end` |
+| `#btn-byok-reveal` | 38 | icône 20 | `p-2` | déjà visible | aucun, voir section 2 |
+| `#btn-byok-copy` | 38 | `text-xs` | **`py-2.5`** | déjà visible | aucun, voir section 2 |
+| `#btn-import-decode` | 34 | `text-sm` | `py-1.5` | transparente | `self-end` |
+| `#btn-test-scope` | 34 | `text-sm` | `py-1.5` | transparente | `self-end` |
+| `#test-method` | 34 | `text-sm` | `py-1.5` | déjà visible | aucun |
+| `.copy-btn` via `RESULT_COPY_BTN_CLASS` | 34 | `text-xs` | **`py-2`** | déjà visible | `self-start` |
+
+### 1.6 Les trois écarts d'intégration
+
+#### `RESULT_COPY_BTN_CLASS` en `py-2` : le dev a raison, je confirme
+
+Ma spec disait `py-1.5`. Ces boutons sont en `text-xs`, dont l'interligne vaut 16 px et non 20. `py-1.5` donne donc 16 plus 12 plus 2, soit **30 px**, alors que `CONTROL_H_SM` en annonce 34. Le niveau 1 et le niveau 3 de la défense en profondeur se contredisaient, et l'état dégradé retombait à 30.
+
+`py-2` donne 16 plus 16 plus 2, soit **34 px**, ce qui aligne les deux niveaux. Aucun changement visuel en nominal, puisque la classe de hauteur imposait déjà 34.
+
+L'erreur venait de ma règle, qui donnait des valeurs de padding fixes au lieu de la soustraction. La table du niveau 1 la corrige à la racine. **Le même défaut existe en sens inverse sur `#btn-byok-copy`**, en `text-xs` à l'échelle 38 avec `py-2` : il vaut 34 intrinsèquement au lieu de 38, et doit passer à `py-2.5`.
+
+#### `self-start` sur `#byok-actions` et non sur les boutons : le dev a raison, je corrige ma spec
+
+Ma spec se contredisait : le tableau d'inventaire désignait les boutons, le JSX de la section 2.2 désignait le conteneur. **Le conteneur fait foi**, et le tableau ci-dessus est corrigé en conséquence.
+
+Le raisonnement du dev est le bon. `self-start` posé sur chaque bouton les sort de l'étirement mutuel du groupe, et « Copier » retombe alors à 34 face à un oeil à 38 dans l'état dégradé.
+
+La règle générale à retenir : **`self-*` se pose sur l'élément qui participe directement à la rangée du champ.** Quand cet élément est un groupe de boutons frères, c'est le groupe qui le porte, et l'étirement mutuel à l'intérieur du groupe est un mécanisme voulu, pas une dépendance subie : deux boutons voisins qui doivent être égaux entre eux sont précisément le cas où l'étirement fait le bon travail.
+
+Avec le passage de `#btn-byok-copy` à `py-2.5`, les deux boutons du groupe valent 38 px intrinsèquement et cet étirement devient un filet de sécurité plutôt qu'un mécanisme porteur. C'est la disposition souhaitable.
+
+#### Les deux écarts résiduels : un fermé, un documenté en tolérance
+
+**Le bouton de suppression, 2 px : je ferme.** C'est une erreur de ma spec, qui indiquait « bordure : aucune ». J'avais réservé la bordure transparente aux boutons à fond plein, alors qu'elle sert précisément à tout contrôle **dépourvu de bordure visible**, ce que ce bouton fantôme est aussi. Mesuré : icône de 20 px avec `p-2` sans bordure donne 36 px, avec bordure transparente donne **38 px**. La règle du niveau 1 est corrigée pour ne plus mentionner le fond mais l'absence de bordure.
+
+**Les deux `select`, 1,5 px : je documente en tolérance.** La boîte de contenu d'un `<select>` dérive de la police et non de l'interligne, ce que le dev a correctement identifié. Mesuré sur banc d'essai, à padding et bordure identiques : un `<input>` fait 38 px, un `<select>` fait **36,5 px**.
+
+Aucun cran de padding Tailwind ne tombe sur 38, et fermer l'écart demanderait une valeur arbitraire calculée pour une police donnée, du type `py-[0.53125rem]`. Ce serait réintroduire exactement la fragilité que ce lot supprime, pour 1,5 px.
+
+**Portée de la tolérance** : elle ne s'applique **qu'à l'état dégradé**. En nominal, `CONTROL_H` impose 38 px et l'écart est nul, ce que j'ai mesuré. Le 1,5 px n'apparaît que si la classe de hauteur manque, c'est-à-dire dans un chemin devenu rare depuis le cache-busting. Un écart de 4 % dans un état de repli est acceptable, là où l'écart de 17,5 px du même contrôle sans padding ne l'était pas.
+
+Pour les `select`, la classe de hauteur reste donc le mécanisme principal et le padding n'est qu'un filet. C'est le seul type de contrôle dans ce cas, et c'est écrit ici pour que personne ne le prenne plus tard pour un oubli.
+
+## 2. Point 6 : la jauge doit s'arrêter à la largeur du champ
+
+### 2.1 Constat
+
+Mesuré à 375 px, bloc ouvert : la jauge fait **309 px** de large, le champ **191 px**. Elle dépasse de **118 px**, soit exactement la largeur des deux boutons et des deux gouttières.
+
+La cause est structurelle : `#byok-strength` est un frère de la rangée, pas du champ. Il occupe donc toute la largeur de la rangée, boutons compris, alors qu'il ne qualifie que le contenu du champ.
+
+### 2.2 Correctif : une colonne qui réunit le champ et sa jauge
+
+```jsx
+<div class="flex flex-wrap gap-2">
+  <div class="min-w-[11rem] flex-1">
+    <input id="byok-key" class="w-full ..." />
+    <div id="byok-strength" class="mt-2 flex gap-1" aria-hidden="true"> ... </div>
+  </div>
+  <div id="byok-actions" class="flex shrink-0 gap-2 self-start"> oeil, Copier </div>
+</div>
+```
+
+Trois déplacements de classes, aucun changement d'identifiant :
+
+- une colonne intermédiaire reçoit `min-w-[11rem] flex-1`, qui quittent l'input
+- l'input passe en `w-full`, il remplit la colonne
+- `#byok-actions` reçoit `self-start` pour rester aligné sur le haut du champ et non centré sur une colonne devenue plus haute
+
+### 2.3 Validation dans les deux dispositions
+
+Le lead demandait de vérifier la cohérence avec le repli sous 360 px. Mesuré :
+
+| Disposition | Champ | Jauge | Alignée | Boutons | Hauteur de rangée |
+| --- | --- | --- | --- | --- | --- |
+| une ligne, conteneur 309 px | 191 px | **191 px** | oui | sur la même ligne | 50 px |
+| repli, conteneur 280 px | 280 px | **280 px** | oui | sous le champ | 96 px |
+
+La jauge suit la largeur du champ dans les deux cas, y compris quand le champ passe en pleine largeur au repli. Le correctif est cohérent avec la spec de repli du lot précédent.
+
+La rangée passe de 38 à 50 px, la jauge étant désormais dans le flux de la colonne au lieu d'être sous la rangée. Le bloc ne grandit pas pour autant : c'est la même hauteur totale, simplement répartie autrement.
+
+---
+
+## 3. Point 7 : il n'existe pas de gabarit d'alerte, il faut le créer
+
+### 3.1 Constat élargi
+
+L'architecte compare deux blocs. En réalité la page en compte six, avec six traitements différents.
+
+| Bloc | Fond et bordure | Bordure gauche | Icône | Padding | Texte |
+| --- | --- | --- | --- | --- | --- |
+| `#byok-warning` | red-50 / red-300 | `border-l-4` | oui | `p-2` | `text-xs` red-800 |
+| `#ttl-warning` | amber-50 / amber-200 | non | non | `p-2` | `text-xs` amber-700 |
+| `#logs-detailed-warning` | amber-50 / amber-200 | non | non | `p-3` | titre gras plus `text-xs` |
+| `#logs-feature-off` | blue-50 / blue-200 | non | non | `p-3` | `text-xs` blue-800 |
+| `#error-banner` | red-50 / red-200 | non | non | `p-3` | `text-sm` red-700 |
+| `#addon-target-warning` | **aucun** | non | non | aucun | `text-xs` amber-700 |
+
+Le padding varie entre rien, `p-2` et `p-3`, la taille de texte entre `xs` et `sm`, les rampes sombres entre `amber-900/30` et `amber-900/20`. La différence que relève l'architecte n'est pas une hiérarchie, c'est une accumulation de décisions locales.
+
+### 3.2 Décision : même gabarit, hiérarchie portée par la seule couleur
+
+Je réponds à l'alternative posée par **la première branche, avec la hiérarchie écrite** : les blocs suivent un gabarit unique, et le niveau de gravité ne change **que** la rampe de couleur.
+
+La structure devient invariante : même padding, même taille de texte, même icône, même bordure gauche. Trois niveaux :
+
+| Niveau | Usage | Rampe claire | Rampe sombre |
+| --- | --- | --- | --- |
+| `info` | état de l'instance, rien à corriger | `bg-blue-50 border-blue-200 border-l-blue-500 text-blue-800` | `dark:bg-blue-900/30 dark:border-blue-700 dark:text-blue-300` |
+| `caution` | imprudence, l'action reste permise | `bg-amber-50 border-amber-200 border-l-amber-500 text-amber-800` | `dark:bg-amber-900/30 dark:border-amber-700 dark:text-amber-300` |
+| `danger` | risque de compromission, ou échec | `bg-red-50 border-red-300 border-l-red-500 text-red-800` | `dark:bg-red-900/30 dark:border-red-700 dark:text-red-300` |
+
+Structure commune, à poser en constante dans `constants.ts` :
+
+```
+flex items-start gap-2 rounded-md border border-l-4 p-2 text-xs
+```
+
+Icône en `h-4 w-4 shrink-0`, toujours `aria-hidden="true"`, triangle d'avertissement pour `caution` et `danger`, cercle d'information pour `info`.
+
+#### Le `display:flex` du gabarit écrase l'attribut `hidden`
+
+Piège rencontré à l'intégration, et il est structurant. Trois des six blocs (`#ttl-warning`, `#addon-target-warning`, `#logs-feature-off`) pilotent leur visibilité par l'attribut `hidden`. Le gabarit leur pose `display:flex`, une déclaration d'auteur, qui bat le `[hidden] { display: none }` de la feuille de l'agent utilisateur. Résultat : les trois blocs deviennent visibles en permanence.
+
+C'est le même conflit que celui du badge de clé personnalisée du lot précédent, dans l'autre sens. Là j'avais tranché par une règle d'évitement : « ne jamais poser une classe utilitaire de `display` sur un élément dont la visibilité est pilotée par `hidden` ». **Cette règle est maintenant caduque**, parce que le gabarit d'alerte a légitimement besoin de `flex` et que trois blocs ont légitimement besoin de `hidden`.
+
+Le correctif appliqué par le dev est le bon, et il est général :
+
+```css
+@layer base {
+  [hidden] { display: none !important; }
+}
+```
+
+Il rend l'attribut `hidden` inconditionnellement prioritaire, ce qui est le comportement que tout le monde suppose déjà. Il retire la charge mentale de vérifier, à chaque ajout de classe, si l'élément est piloté par `hidden`. **Il remplace ma règle d'évitement du lot précédent**, qui n'était qu'un contournement.
+
+#### `showError` écrasait l'icône
+
+Second piège : `showError` remplaçait le contenu de la bannière par `textContent`, ce qui supprimait l'icône du gabarit dès le premier affichage d'erreur. Le dev a ajouté un élément dédié pour porter le message, l'icône restant en place. C'est la bonne réponse, et elle vaut comme règle : **un bloc d'alerte dont le contenu est écrit par le JS doit avoir un noeud de texte distinct de son icône**. L'identifiant est inventorié en section 6.
+
+**Pourquoi la couleur seule suffit à hiérarchiser** : elle n'est jamais le seul vecteur, puisque le texte dit toujours ce qui se passe et que l'icône diffère entre information et avertissement. Le critère 1.4.1 est respecté. Ajouter en plus une icône sur l'un et pas sur l'autre, ou une bordure épaisse sur l'un et pas sur l'autre, ne renforce pas la hiérarchie, cela brouille la lecture du gabarit.
+
+### 3.3 Affectation des six blocs
+
+| Bloc | Niveau | Justification |
+| --- | --- | --- |
+| `#byok-warning` | `danger` | une clé partagée compromise expose tous les blobs générés avec elle, c'est une compromission en chaîne |
+| `#error-banner` | `danger` | échec effectif d'une opération |
+| `#ttl-warning` | `caution` | une URL sans expiration est une imprudence, pas une compromission |
+| `#logs-detailed-warning` | `caution` | capture de payloads potentiellement sensibles, l'utilisateur choisit en connaissance de cause |
+| `#addon-target-warning` | `caution` | incohérence probable entre le mode et la cible, non bloquante |
+| `#logs-feature-off` | `info` | état de l'instance, aucune action attendue de l'utilisateur |
+
+La hiérarchie est donc : `danger` pour ce qui compromet ou a échoué, `caution` pour ce qui est permis mais risqué, `info` pour ce qui est constaté. C'est cette phrase qui doit figurer dans la doc de contribution.
+
+Deux conséquences visibles : `#addon-target-warning` gagne un encadré, il n'en avait aucun alors qu'il porte le même niveau que `#ttl-warning` ; `#error-banner` passe de `text-sm` à `text-xs` et de `p-3` à `p-2`, ce qui l'aligne sur les autres sans réduire sa lisibilité, sa couleur et sa position en faisant déjà un bloc saillant.
+
+Le `font-semibold` sur la totalité du texte de `#logs-detailed-warning` disparaît : sur un bloc de deux lignes, le gras intégral ne hiérarchise plus rien.
+
+**Le titre « Attention » en gras disparaît aussi, et je confirme cette lecture.** Ma consigne visait le gras appliqué à tout le texte, mais la conclusion vaut également pour le titre, et pour une raison propre au gabarit : dans un bloc qui porte déjà un triangle d'avertissement et une rampe ambre, le mot « Attention » ne transporte aucune information que l'icône et la couleur ne donnent pas déjà. Il consomme une ligne sur les deux du budget pour répéter le niveau de gravité.
+
+La règle qui en découle : **un bloc d'alerte n'a pas de titre.** Le niveau est porté par l'icône et la couleur, le texte dit ce qui se passe et ce qu'il faut faire. Si un bloc a besoin d'un titre pour être compris, c'est que son texte est trop long pour un bloc d'alerte et qu'il relève de la documentation.
+
+C'est du copy, donc le PO tranche derrière moi. S'il tient au titre, il faut savoir qu'il coûte une troisième ligne et fait sortir le bloc du budget de deux lignes fixé au lot précédent.
+
+---
+
+## 4. Les deux points pour information
+
+### 4.1 Les liens « En savoir plus » : le mécanisme n'a pas de faille sur mobile
+
+Testé sur le build local à 375 px, depuis l'onglet Changelog, donc dans le pire cas où la cible est dans un panneau masqué :
+
+```
+onglet Doc avant  : aria-selected=false
+onglet Doc après  : aria-selected=true
+défilement        : 758 -> 3865
+cible visible     : oui
+focus             : doc-client-key
+```
+
+Les deux liens existent avec leurs `data-goto-doc` et `data-return-label`, les deux cibles ont bien `tabindex="-1"`, `role="group"` et `aria-labelledby`. **Le mécanisme fonctionne de bout en bout, y compris sur mobile.** Il n'y a rien à corriger dans la spec.
+
+Si le comportement est inerte en production, l'explication la plus probable est celle de la section 1.3, un `static/client.js` périmé au même titre que la feuille de style.
+
+Si ce n'est pas ça, le seul piège d'intégration que je vois est un **ordre d'exécution inversé** : `scrollIntoView` appelé avant l'activation de l'onglet ne fait rien, parce que le panneau est encore en `display:none` et n'a donc aucune position. La spec impose l'ordre activation, ouverture des `details`, défilement, focus. C'est la première chose à vérifier dans le code du gestionnaire.
+
+### 4.2 L'exemple Scalingo Database API : pas de structure nouvelle, mais un choix à faire
+
+Le panneau Exemples est constitué de blocs `<details>` dans `sidebar-guides.tsx`. Un exemple supplémentaire suit ce gabarit sans rien inventer, donc **aucune structure particulière n'est nécessaire**.
+
+Une recommandation de conception en revanche. Le formulaire possède déjà `#btn-preset-scalingo-db`, qui pré-remplit cible, mode d'auth, région et scope de départ. Un exemple qui se contenterait de lister ces valeurs en texte demanderait à l'utilisateur de les recopier, alors qu'un bouton les applique déjà. **L'exemple doit donc renvoyer vers le preset plutôt que dupliquer son contenu**, sur le même principe que les liens « En savoir plus » mais en sens inverse.
+
+Cela suppose un mécanisme symétrique, du panneau vers le formulaire, que je n'ai pas spécifié et qui n'existe pas. Il est simple, un `[data-apply-preset="scalingo-db"]` qui déclenche le clic sur le bouton de preset puis renvoie le focus sur le champ cible, mais **c'est du périmètre à ouvrir, pas un ajustement**. À arbitrer avant que le PO écrive le contenu : soit l'exemple reste descriptif et autonome, soit il devient actionnable et il faut ce mécanisme.
+
+---
+
+## 5. Ce qu'il faut vérifier avant de refermer le lot
+
+Le défaut de ce lot était invisible sur le code et visible seulement sur la page servie. La recette doit donc porter sur le rendu, pas sur la revue de code.
+
+1. **Reconstruire les assets et vérifier que les quatre règles sont présentes** dans `static/styles.css`, en cherchant les valeurs brutes et non les sélecteurs échappés : `grep -c '2.375rem'`, `grep -c '2.125rem'`, `grep -c 'items-end'`.
+2. **Mesurer à 375 px** les cinq paires de la section 1.1, toutes à 0 px d'écart.
+3. **Recommencer la mesure après avoir supprimé les quatre règles** de la feuille de style à l'exécution. Avec le correctif de la section 1.4, les hauteurs doivent **rester correctes**, puisque le padding et `self-end` prennent le relais. C'est le test qui prouve que le point unique de défaillance a disparu, et c'est le seul qui aurait attrapé la régression.
+4. **Vérifier la jauge** dans les deux dispositions, à 375 px et sous 360 px.
+5. **Vérifier les six blocs d'alerte** après passage au gabarit unique, en clair et en sombre.
+6. **Vérifier que les trois blocs pilotés par `hidden` sont bien masqués au chargement** : `#ttl-warning`, `#addon-target-warning` et `#logs-feature-off`. C'est le test du `[hidden]` en couche de base, et il échouait avant le correctif.
+7. **Déclencher une erreur et vérifier que l'icône de la bannière survit**, la régression `showError` remplaçant tout le contenu.
+8. **Vider le cache et recharger** après déploiement, puis recharger une seconde fois sans vider : c'est le scénario que le cache-busting doit rendre indolore.
+
+---
+
+## 6. Identifiants et fichiers : ce qui change
+
+**Inventaire faisant foi.** Cette section est le contrat de sélecteurs de ce lot. Toute mention d'identifiant ailleurs dans le document est une illustration locale, pas un décompte : en cas d'écart, c'est cette liste qui fait référence.
+
+**Aucun renommage.** Tous les `id` consommés par `assertElement` sont préservés.
+
+**Ajoutés :**
+
+- `#error-banner-message`, noeud de texte de la bannière d'erreur, distinct de son icône. `showError` écrit désormais dans ce noeud et non plus dans `#error-banner`, dont le `textContent` détruirait l'icône du gabarit. Le nom est une proposition, seule compte la séparation icône et texte.
+
+**Changent de parent, `id` inchangé :**
+
+- `#byok-key` et `#byok-strength` passent dans une colonne intermédiaire commune, section 2.2. La colonne n'a pas besoin d'identifiant.
+
+**Supprimés :** aucun.
+
+**Hors identifiants**, deux changements structurels à ne pas oublier :
+
+- une règle `[hidden] { display: none !important; }` en `@layer base` dans `src/ui/tailwind.css`, qui ne contient aujourd'hui que les trois directives Tailwind
+- trois constantes de gabarit d'alerte dans `src/ui/config/constants.ts`, une par niveau, plus la structure commune
+
+---
+
+## 7. Ce que je signale au lead
+
+**Je m'étais trompé de mécanisme sur la cause racine.** J'avais conclu à un `static/` périmé au déploiement, le lead a vérifié que le déploiement est correct. La vraie cause est le cache navigateur, `max-age=86400` sur des noms de fichiers stables, qui fait cohabiter un HTML neuf et des assets vieux de moins de 24 heures. Le raisonnement reliant les six symptômes à une cause unique tenait, l'inférence sur le mécanisme non : j'ai conclu d'un rendu faux à un déploiement faux sans vérifier la production, alors que la question « quel navigateur voit quoi » restait ouverte. Le cache-busting est le correctif de fond et il est au bon endroit.
+
+**Cela ne périme pas le correctif de conception.** Un cache-busting empêche la désynchronisation d'arriver, il n'empêche pas la mise en page de s'effondrer quand elle arrive. Toute désynchronisation future entre balisage et feuille de style reproduirait les cinq symptômes. Le test 3 de la section 5, mesurer après suppression des règles, reste la garantie, et il passe.
+
+**Les deux arbitrages du dev sont justes, je confirme les deux.** Le `py-2` sur `RESULT_COPY_BTN_CLASS` est correct et mon `py-1.5` était faux : ces boutons sont en `text-xs`, dont l'interligne vaut 16 px et non 20. Ma règle donnait des valeurs de padding fixes en supposant un interligne constant. Elle est remplacée par une soustraction et une table à six entrées, section 1.4. **Le même défaut existe en sens inverse sur `#btn-byok-copy`**, en `text-xs` à l'échelle 38 avec `py-2`, qui vaut donc 34 et doit passer à `py-2.5`. Le dev ne l'a pas vu parce que l'étirement du groupe le masque en nominal.
+
+Le `self-start` sur `#byok-actions` est également correct, et ma spec se contredisait : le tableau disait les boutons, le JSX disait le conteneur. Le conteneur fait foi, le tableau est corrigé. La règle générale est maintenant écrite : `self-*` se pose sur l'élément qui participe à la rangée du champ, et l'étirement mutuel entre boutons frères d'un même groupe est un mécanisme voulu, pas une dépendance subie.
+
+**Sur les deux écarts résiduels, j'en ferme un et je documente l'autre.** Le bouton de suppression est une erreur de ma spec, qui réservait la bordure transparente aux boutons à fond plein alors qu'elle vaut pour tout contrôle sans bordure visible, boutons fantômes compris. Mesuré : 36 px sans, 38 px avec. Fermé.
+
+Les 1,5 px des `select` deviennent une tolérance écrite. La boîte de contenu d'un `select` dérive de la police et non de l'interligne, et aucun cran Tailwind ne tombe sur 38. Fermer l'écart demanderait une valeur arbitraire calculée pour une police donnée, ce qui réintroduirait exactement la fragilité que ce lot supprime, pour 1,5 px. La tolérance ne vaut **que pour l'état dégradé** : en nominal la classe de hauteur impose 38 et l'écart est nul. C'est le seul type de contrôle dans ce cas, et c'est écrit pour que personne ne le prenne plus tard pour un oubli.
+
+**Le correctif `[hidden] { display: none !important }` est la bonne réponse et il retire une de mes règles.** Au lot précédent j'avais tranché le conflit du badge par une règle d'évitement, ne jamais poser de classe de `display` sur un élément piloté par `hidden`. Le gabarit d'alerte la rend intenable, puisqu'il a besoin de `flex` et que trois blocs ont besoin de `hidden`. La couche de base rend l'attribut inconditionnellement prioritaire, ce que tout le monde suppose déjà, et supprime la charge mentale de vérifier à chaque ajout de classe. **Elle remplace ma règle d'évitement**, qui n'était qu'un contournement.
+
+**Sur le titre « Attention », je confirme sa disparition.** Dans un bloc qui porte déjà un triangle et une rampe ambre, le mot ne transporte rien que l'icône et la couleur ne disent pas, et il consomme une ligne sur les deux du budget. La règle qui en découle est qu'un bloc d'alerte n'a pas de titre : si un bloc en a besoin pour être compris, son texte relève de la documentation. C'est du copy, le PO tranche derrière moi, en sachant qu'un titre coûte une troisième ligne et fait sortir du budget fixé au lot précédent.
+
+**Un point de forme corrigé** : l'en-tête renvoyait à une section 7 inexistante. L'inventaire des identifiants est maintenant en section 6, et il est le contrat de sélecteurs de ce lot.

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -22,6 +22,7 @@ import { obtainAddonToken } from "../auth/credentials.ts";
 import { validateScopeLimits } from "../middleware/scope-limits.ts";
 import { renderLlmsTxt } from "./llms.ts";
 import { ConfigPage } from "../ui/config-page.tsx";
+import { ASSET_VERSION } from "../ui/asset-version.ts";
 import {
   type BodyFilter,
   checkAccess,
@@ -31,13 +32,6 @@ import {
   type Scope,
 } from "../middleware/scopes.ts";
 import { FGP_SOURCE_HEADER, FGP_SOURCE_PROXY } from "../constants.ts";
-
-let commitHash = "dev";
-try {
-  commitHash = Deno.readTextFileSync("static/version.txt").trim();
-} catch {
-  // no version.txt, run deno task build to generate it
-}
 
 function getRequestOrigin(c: Context): string {
   const forwardedProto = c.req.header("X-Forwarded-Proto");
@@ -685,7 +679,7 @@ export const uiRoutes = new OpenAPIHono({
 
 uiRoutes.get("/", (c) => {
   c.header("Link", LLMS_LINK_HEADER);
-  return c.html(<ConfigPage commitHash={commitHash} />);
+  return c.html(<ConfigPage commitHash={ASSET_VERSION} />);
 });
 
 uiRoutes.get(LLMS_TXT_PATH, (c) => {

--- a/src/ui/asset-version.ts
+++ b/src/ui/asset-version.ts
@@ -1,0 +1,14 @@
+let resolved = "dev";
+try {
+  resolved = Deno.readTextFileSync("static/version.txt").trim() || "dev";
+} catch {
+  // no version.txt, run deno task build to generate it
+}
+
+export const ASSET_VERSION = resolved;
+
+// Les noms de fichiers de static/ sont stables et servis en max-age=86400 : sans ce suffixe,
+// un deploiement laisse 24h de CSS et de JS perimes aux visiteurs deja venus.
+export function assetUrl(path: string): string {
+  return `${path}?v=${encodeURIComponent(ASSET_VERSION)}`;
+}

--- a/src/ui/asset-version.ts
+++ b/src/ui/asset-version.ts
@@ -10,5 +10,6 @@ export const ASSET_VERSION = resolved;
 // Les noms de fichiers de static/ sont stables et servis en max-age=86400 : sans ce suffixe,
 // un deploiement laisse 24h de CSS et de JS perimes aux visiteurs deja venus.
 export function assetUrl(path: string): string {
-  return `${path}?v=${encodeURIComponent(ASSET_VERSION)}`;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}v=${encodeURIComponent(ASSET_VERSION)}`;
 }

--- a/src/ui/client.ts
+++ b/src/ui/client.ts
@@ -33,7 +33,7 @@ import type { AppsPermissionsState } from "./client/types.ts";
   const appsPerms: AppsPermissionsState = {};
 
   function showError(msg: string): void {
-    els.errorBanner.textContent = msg;
+    els.errorBannerMessage.textContent = msg;
     els.errorBanner.classList.remove("hidden");
     setTimeout(function () {
       els.errorBanner.classList.add("hidden");

--- a/src/ui/client/elements.ts
+++ b/src/ui/client/elements.ts
@@ -21,6 +21,7 @@ export function getElements() {
     scopesTextarea: assertElement("scopes", HTMLTextAreaElement),
     resultSection: assertElement("result-section", HTMLElement),
     errorBanner: assertElement("error-banner", HTMLElement),
+    errorBannerMessage: assertElement("error-banner-message", HTMLElement),
     customTtlWrapper: assertElement("custom-ttl-wrapper", HTMLElement),
     ttlWarning: assertElement("ttl-warning", HTMLElement),
     scopeChips: assertElement("scope-chips", HTMLElement),

--- a/src/ui/client/elements.ts
+++ b/src/ui/client/elements.ts
@@ -21,7 +21,7 @@ export function getElements() {
     scopesTextarea: assertElement("scopes", HTMLTextAreaElement),
     resultSection: assertElement("result-section", HTMLElement),
     errorBanner: assertElement("error-banner", HTMLElement),
-    errorBannerMessage: assertElement("error-banner-message", HTMLElement),
+    errorBannerMessage: assertElement("error-banner-message", HTMLSpanElement),
     customTtlWrapper: assertElement("custom-ttl-wrapper", HTMLElement),
     ttlWarning: assertElement("ttl-warning", HTMLElement),
     scopeChips: assertElement("scope-chips", HTMLElement),

--- a/src/ui/config-page.tsx
+++ b/src/ui/config-page.tsx
@@ -1,4 +1,5 @@
 import { Layout } from "./layout.tsx";
+import { assetUrl } from "./asset-version.ts";
 import { PageFooter, PageHeader } from "./config/page-chrome.tsx";
 import { NameSection, PresetSection, TargetSection } from "./config/form-identity.tsx";
 import {
@@ -45,7 +46,7 @@ export function ConfigPage({ commitHash = "dev" }: { commitHash?: string }) {
 
             <ErrorBanner />
 
-            <script defer src="/static/client.js" />
+            <script defer src={assetUrl("/static/client.js")} />
           </div>
 
           <Sidebar />

--- a/src/ui/config/constants.ts
+++ b/src/ui/config/constants.ts
@@ -23,14 +23,15 @@ export const SCALINGO_REGIONS = [
 export const FIELD_CLASS =
   "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-mono focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none aria-[invalid=true]:border-red-400 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 dark:aria-[invalid=true]:border-red-500";
 
-// Hauteur explicite des controles. Ne jamais compter sur align-items: stretch pour
-// egaliser un bouton et un champ : l'egalite disparait des que le bouton passe sur sa
-// propre ligne en flex-wrap, ce qui arrive sur mobile.
+// Defense en profondeur sur la geometrie des controles. Le padding vertical porte la
+// hauteur intrinseque, `self-end`/`self-start` neutralisent le align-items du parent, et
+// ces deux classes ne font que confirmer : si elles disparaissent de la feuille compilee,
+// la mise en page tient toujours.
 export const CONTROL_H = "h-[2.375rem]";
 export const CONTROL_H_SM = "h-[2.125rem]";
 
 export const REMOVE_BTN_CLASS =
-  "h-[2.375rem] w-[2.375rem] shrink-0 inline-flex items-center justify-center rounded-md text-gray-400 hover:text-red-600 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-fgp-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent dark:hover:text-red-400 dark:hover:bg-red-900/30";
+  "h-[2.375rem] w-[2.375rem] self-end shrink-0 inline-flex items-center justify-center rounded-md border border-transparent p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-fgp-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent dark:hover:text-red-400 dark:hover:bg-red-900/30";
 
 export const ADD_BTN_CLASS =
   "mt-3 inline-flex items-center gap-1 text-sm font-medium text-fgp-600 hover:text-fgp-800 dark:text-fgp-400 dark:hover:text-fgp-200 focus:outline-none focus:underline disabled:text-gray-400 disabled:cursor-not-allowed disabled:no-underline dark:disabled:text-gray-500";
@@ -56,4 +57,18 @@ export const RESULT_INPUT_CLASS =
   "flex-1 rounded-md border border-green-300 bg-white px-3 py-2 text-xs font-mono text-gray-800 select-all dark:bg-gray-800 dark:border-green-700 dark:text-gray-200";
 
 export const RESULT_COPY_BTN_CLASS =
-  "copy-btn h-[2.125rem] inline-flex items-center justify-center rounded-md border border-green-300 bg-white px-3 text-xs font-medium text-green-700 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 dark:bg-gray-800 dark:border-green-700 dark:text-green-300 dark:hover:bg-gray-700";
+  "copy-btn h-[2.125rem] self-start inline-flex items-center justify-center rounded-md border border-green-300 bg-white px-3 py-2 text-xs font-medium text-green-700 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 dark:bg-gray-800 dark:border-green-700 dark:text-green-300 dark:hover:bg-gray-700";
+
+// Gabarit d'alerte unique : la structure ne change jamais, seule la rampe de couleur porte
+// le niveau. La couleur n'est jamais seule a le porter, le texte dit ce qui se passe et
+// l'icone distingue l'information de l'avertissement (WCAG 1.4.1).
+const ALERT_BASE_CLASS = "flex items-start gap-2 rounded-md border border-l-4 p-2 text-xs";
+
+export const ALERT_INFO_CLASS =
+  `${ALERT_BASE_CLASS} border-blue-200 border-l-blue-500 bg-blue-50 text-blue-800 dark:border-blue-700 dark:border-l-blue-500 dark:bg-blue-900/30 dark:text-blue-300`;
+
+export const ALERT_CAUTION_CLASS =
+  `${ALERT_BASE_CLASS} border-amber-200 border-l-amber-500 bg-amber-50 text-amber-800 dark:border-amber-700 dark:border-l-amber-500 dark:bg-amber-900/30 dark:text-amber-300`;
+
+export const ALERT_DANGER_CLASS =
+  `${ALERT_BASE_CLASS} border-red-300 border-l-red-500 bg-red-50 text-red-800 dark:border-red-700 dark:border-l-red-500 dark:bg-red-900/30 dark:text-red-300`;

--- a/src/ui/config/form-auth.tsx
+++ b/src/ui/config/form-auth.tsx
@@ -1,5 +1,6 @@
 import {
   ADD_BTN_CLASS,
+  ALERT_CAUTION_CLASS,
   AUTH_MODES,
   CONTROL_H,
   FIELD_CLASS,
@@ -11,7 +12,7 @@ import {
   SCALINGO_REGIONS,
   SUB_LABEL_CLASS,
 } from "./constants.ts";
-import { EyeIcon, TrashIcon } from "./icons.tsx";
+import { AlertTriangleIcon, EyeIcon, TrashIcon } from "./icons.tsx";
 
 export function AuthModeSection() {
   return (
@@ -179,15 +180,18 @@ export function ScalingoAddonSection() {
         <p
           id="addon-target-warning"
           hidden
-          class="mt-2 text-xs text-amber-700 dark:text-amber-300"
+          class={`mt-2 ${ALERT_CAUTION_CLASS}`}
         >
-          Cette cible ne ressemble pas &agrave; une Database API Scalingo. V&eacute;rifiez l'URL
-          cible.
+          <AlertTriangleIcon />
+          <span>
+            Cette cible ne ressemble pas &agrave; une Database API Scalingo. V&eacute;rifiez l'URL
+            cible.
+          </span>
         </p>
 
         <div class="mt-4 flex flex-wrap items-start gap-2">
           <div class="min-w-[14rem] flex-1">
-            <div class="flex items-end gap-2">
+            <div class="flex gap-2">
               <div class="min-w-0 flex-1">
                 <label
                   for="addon-app"
@@ -210,7 +214,7 @@ export function ScalingoAddonSection() {
               <button
                 type="button"
                 id="btn-addon-load"
-                class={`${CONTROL_H} shrink-0 inline-flex items-center justify-center rounded-md bg-fgp-600 px-3 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
+                class={`${CONTROL_H} self-end shrink-0 inline-flex items-center justify-center rounded-md border border-transparent bg-fgp-600 px-3 py-2 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
               >
                 Charger
               </button>
@@ -236,7 +240,7 @@ export function ScalingoAddonSection() {
             <select
               id="addon-select"
               disabled
-              class={`${CONTROL_H} w-full rounded-md border border-gray-300 bg-white px-3 text-sm focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none disabled:bg-gray-50 disabled:text-gray-400 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:disabled:bg-gray-800/50 dark:disabled:text-gray-500`}
+              class={`${CONTROL_H} w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none disabled:bg-gray-50 disabled:text-gray-400 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:disabled:bg-gray-800/50 dark:disabled:text-gray-500`}
             >
               <option value="">Choisissez une base de donn&eacute;es</option>
             </select>
@@ -286,7 +290,7 @@ export function TokenSection() {
         <button
           type="button"
           id="btn-load-apps"
-          class={`${CONTROL_H} hidden shrink-0 inline-flex items-center justify-center rounded-md bg-fgp-600 px-4 text-sm font-medium text-white shadow-sm hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
+          class={`${CONTROL_H} hidden self-end shrink-0 inline-flex items-center justify-center rounded-md border border-transparent bg-fgp-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
         >
           Charger les apps
         </button>

--- a/src/ui/config/form-delivery.tsx
+++ b/src/ui/config/form-delivery.tsx
@@ -1,4 +1,6 @@
 import {
+  ALERT_CAUTION_CLASS,
+  ALERT_DANGER_CLASS,
   CONTROL_H,
   HINT_CLASS,
   INPUT_CLASS,
@@ -6,7 +8,7 @@ import {
   PILL_CLASS,
   TTL_PRESETS,
 } from "./constants.ts";
-import { EyeIcon } from "./icons.tsx";
+import { AlertTriangleIcon, EyeIcon } from "./icons.tsx";
 
 export function TtlSection() {
   return (
@@ -49,10 +51,11 @@ export function TtlSection() {
         </div>
         <div
           id="ttl-warning"
-          class="mt-2 hidden rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700 dark:bg-amber-900/30 dark:border-amber-700 dark:text-amber-300"
+          class={`mt-2 hidden ${ALERT_CAUTION_CLASS}`}
           role="alert"
         >
-          Attention : sans expiration, cette URL restera valide indéfiniment.
+          <AlertTriangleIcon />
+          <span>Attention : sans expiration, cette URL restera valide indéfiniment.</span>
         </div>
       </fieldset>
     </section>
@@ -82,10 +85,6 @@ export function ByokSection() {
           />
         </svg>
         <span class="min-w-0 flex-1">Utiliser ma propre cl&eacute; client</span>
-        {
-          /* Pas de classe utilitaire de display ici : elle l'emporterait sur le
-            [hidden] { display: none } du preflight et le badge resterait visible. */
-        }
         <span
           id="byok-active-badge"
           hidden
@@ -99,20 +98,9 @@ export function ByokSection() {
       <div class="space-y-3 border-t border-gray-200 px-4 py-3 dark:border-gray-700">
         <p
           id="byok-warning"
-          class="flex items-start gap-2 rounded-md border border-red-300 border-l-4 border-l-red-500 bg-red-50 p-2 text-xs text-red-800 dark:border-red-700 dark:border-l-red-500 dark:bg-red-900/30 dark:text-red-300"
+          class={ALERT_DANGER_CLASS}
         >
-          <svg
-            class="h-4 w-4 shrink-0 text-red-600 dark:text-red-400"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-              clip-rule="evenodd"
-            />
-          </svg>
+          <AlertTriangleIcon />
           <span>
             R&eacute;utiliser une cl&eacute; lie les blobs : sa fuite rend d&eacute;chiffrables tous
             ceux g&eacute;n&eacute;r&eacute;s avec elle.
@@ -137,28 +125,53 @@ export function ByokSection() {
           </div>
 
           <div class="flex flex-wrap gap-2">
-            <input
-              type="password"
-              id="byok-key"
-              placeholder="24 caract&#232;res minimum"
-              autocomplete="off"
-              data-1p-ignore
-              data-lpignore="true"
-              spellcheck={false}
-              aria-describedby="byok-warning byok-strength-label byok-hint"
-              class="min-w-[11rem] flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-mono focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none aria-[invalid=true]:border-red-400 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 dark:aria-[invalid=true]:border-red-500"
-            />
+            <div class="min-w-[11rem] flex-1">
+              <input
+                type="password"
+                id="byok-key"
+                placeholder="24 caract&#232;res minimum"
+                autocomplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                spellcheck={false}
+                aria-describedby="byok-warning byok-strength-label byok-hint"
+                class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-mono focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none aria-[invalid=true]:border-red-400 aria-[invalid=true]:focus:border-red-500 aria-[invalid=true]:focus:ring-red-500 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 dark:aria-[invalid=true]:border-red-500"
+              />
+
+              {
+                /* La jauge est fille du champ et non soeur de la rangee : soeur des
+                  boutons, elle prenait leur largeur en plus de celle du champ. */
+              }
+              <div id="byok-strength" class="mt-2 flex gap-1" aria-hidden="true">
+                <span
+                  data-byok-segment
+                  class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
+                >
+                </span>
+                <span
+                  data-byok-segment
+                  class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
+                >
+                </span>
+                <span
+                  data-byok-segment
+                  class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
+                >
+                </span>
+              </div>
+            </div>
+
             {
               /* Groupes : sous 360 px la rangee replie de toute facon, avec ce conteneur
                 elle replie proprement et le champ y gagne de la largeur. */
             }
-            <div id="byok-actions" class="flex shrink-0 gap-2">
+            <div id="byok-actions" class="flex shrink-0 gap-2 self-start">
               <button
                 type="button"
                 id="btn-byok-reveal"
                 aria-pressed="false"
                 aria-label="Afficher la cl&#233;"
-                class={`${CONTROL_H} w-[2.375rem] shrink-0 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-fgp-500 dark:border-gray-600 dark:hover:text-gray-200`}
+                class={`${CONTROL_H} w-[2.375rem] shrink-0 inline-flex items-center justify-center rounded-md border border-gray-300 p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-fgp-500 dark:border-gray-600 dark:hover:text-gray-200`}
               >
                 <EyeIcon />
               </button>
@@ -166,29 +179,11 @@ export function ByokSection() {
                 type="button"
                 id="btn-byok-copy"
                 data-copy="byok-key"
-                class={`${CONTROL_H} copy-btn shrink-0 inline-flex items-center justify-center rounded-md border border-gray-300 px-3 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-fgp-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700`}
+                class={`${CONTROL_H} copy-btn shrink-0 inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-fgp-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700`}
               >
                 Copier
               </button>
             </div>
-          </div>
-
-          <div id="byok-strength" class="mt-2 flex gap-1" aria-hidden="true">
-            <span
-              data-byok-segment
-              class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
-            >
-            </span>
-            <span
-              data-byok-segment
-              class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
-            >
-            </span>
-            <span
-              data-byok-segment
-              class="h-1 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
-            >
-            </span>
           </div>
 
           <p

--- a/src/ui/config/form-identity.tsx
+++ b/src/ui/config/form-identity.tsx
@@ -118,7 +118,7 @@ export function PresetSection() {
             <button
               type="button"
               id="btn-import-decode"
-              class={`${CONTROL_H_SM} inline-flex items-center justify-center rounded-md bg-fgp-600 px-4 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
+              class={`${CONTROL_H_SM} self-end inline-flex items-center justify-center rounded-md border border-transparent bg-fgp-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
             >
               D&eacute;coder
             </button>

--- a/src/ui/config/form-scopes.tsx
+++ b/src/ui/config/form-scopes.tsx
@@ -76,7 +76,7 @@ export function TestScopeSection() {
             </label>
             <select
               id="test-method"
-              class={`${CONTROL_H_SM} w-full rounded-md border border-gray-300 bg-white px-2 text-sm focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200`}
+              class={`${CONTROL_H_SM} w-full rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm focus:border-fgp-500 focus:ring-1 focus:ring-fgp-500 outline-none dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200`}
             >
               <option value="GET">GET</option>
               <option value="POST">POST</option>
@@ -123,7 +123,7 @@ export function TestScopeSection() {
           <button
             type="button"
             id="btn-test-scope"
-            class={`${CONTROL_H_SM} inline-flex items-center justify-center rounded-md bg-fgp-600 px-4 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
+            class={`${CONTROL_H_SM} self-end inline-flex items-center justify-center rounded-md border border-transparent bg-fgp-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-fgp-700 focus:outline-none focus:ring-2 focus:ring-fgp-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:focus:ring-offset-gray-900`}
           >
             Tester
           </button>

--- a/src/ui/config/icons.tsx
+++ b/src/ui/config/icons.tsx
@@ -23,6 +23,30 @@ export function EyeIcon({ size = "h-5 w-5" }: { size?: string }) {
   );
 }
 
+export function AlertTriangleIcon() {
+  return (
+    <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path
+        fill-rule="evenodd"
+        d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function AlertInfoIcon() {
+  return (
+    <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path
+        fill-rule="evenodd"
+        d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export function GitHubMarkIcon({ size }: { size: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/src/ui/config/result.tsx
+++ b/src/ui/config/result.tsx
@@ -1,4 +1,10 @@
-import { RESULT_COPY_BTN_CLASS, RESULT_INPUT_CLASS, RESULT_LABEL_CLASS } from "./constants.ts";
+import {
+  ALERT_DANGER_CLASS,
+  RESULT_COPY_BTN_CLASS,
+  RESULT_INPUT_CLASS,
+  RESULT_LABEL_CLASS,
+} from "./constants.ts";
+import { AlertTriangleIcon } from "./icons.tsx";
 export function ResultSection() {
   return (
     <section
@@ -109,7 +115,7 @@ export function ResultSection() {
             <button
               type="button"
               data-copy="result-curl"
-              class="copy-btn self-start rounded-md border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 dark:bg-gray-800 dark:border-green-700 dark:text-green-300 dark:hover:bg-gray-700"
+              class={RESULT_COPY_BTN_CLASS}
               aria-label="Copier la commande curl"
             >
               Copier
@@ -129,7 +135,7 @@ export function ResultSection() {
             <button
               type="button"
               data-copy="result-curl-header"
-              class="copy-btn self-start rounded-md border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 dark:bg-gray-800 dark:border-green-700 dark:text-green-300 dark:hover:bg-gray-700"
+              class={RESULT_COPY_BTN_CLASS}
               aria-label="Copier la commande curl header mode"
             >
               Copier
@@ -145,9 +151,12 @@ export function ErrorBanner() {
   return (
     <div
       id="error-banner"
-      class="mt-4 hidden rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300"
+      class={`mt-4 hidden ${ALERT_DANGER_CLASS}`}
       role="alert"
     >
+      <AlertTriangleIcon />
+      {/* Le message va dans ce span, pas sur le conteneur : textContent effacerait l'icone. */}
+      <span id="error-banner-message"></span>
     </div>
   );
 }

--- a/src/ui/config/sidebar-panels.tsx
+++ b/src/ui/config/sidebar-panels.tsx
@@ -1,5 +1,7 @@
 import { renderChangelog } from "../changelog-renderer.tsx";
 import { CHANGELOG_MARKDOWN } from "../changelog-data.ts";
+import { ALERT_CAUTION_CLASS, ALERT_INFO_CLASS } from "./constants.ts";
+import { AlertInfoIcon, AlertTriangleIcon } from "./icons.tsx";
 
 export function ExamplesPanel() {
   return (
@@ -172,12 +174,13 @@ export function LogsPanel() {
       <div
         id="logs-feature-off"
         hidden
-        class="rounded-md bg-blue-50 border border-blue-200 p-3 dark:bg-blue-900/20 dark:border-blue-800"
+        class={ALERT_INFO_CLASS}
       >
-        <p class="text-xs text-blue-800 dark:text-blue-300">
+        <AlertInfoIcon />
+        <span>
           Les logs sont d&eacute;sactiv&eacute;s sur cette instance FGP. Contactez l'administrateur
           pour activer <code class="font-mono">FGP_LOGS_ENABLED</code>.
-        </p>
+        </span>
       </div>
 
       <fieldset id="logs-toggles" class="space-y-4">
@@ -235,16 +238,14 @@ export function LogsPanel() {
       <div
         id="logs-detailed-warning"
         hidden
-        class="rounded-md bg-amber-50 border border-amber-200 p-3 dark:bg-amber-900/20 dark:border-amber-800"
+        class={ALERT_CAUTION_CLASS}
       >
-        <p class="text-xs font-semibold text-amber-800 dark:text-amber-300 mb-1">
-          Attention
-        </p>
-        <p class="text-xs text-amber-700 dark:text-amber-400">
+        <AlertTriangleIcon />
+        <span>
           Activez uniquement si vous avez besoin d'inspecter les payloads. Le body peut contenir des
           informations sensibles, n'ouvrez <code class="font-mono">/logs</code>{" "}
           que sur un poste de confiance.
-        </p>
+        </span>
       </div>
 
       <hr class="border-gray-200 dark:border-gray-700" />

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -1,6 +1,8 @@
 import type { Child } from "hono/jsx";
 import { raw } from "hono/html";
 
+import { assetUrl } from "./asset-version.ts";
+
 const FGP_LOGO_SVG =
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none"><path d="M16 2L4 8v8c0 7.2 5.1 13.3 12 15 6.9-1.7 12-7.8 12-15V8L16 2z" fill="#4c6ef5" opacity="0.15"/><path d="M16 2L4 8v8c0 7.2 5.1 13.3 12 15 6.9-1.7 12-7.8 12-15V8L16 2z" stroke="#4c6ef5" stroke-width="1.5" fill="none"/><rect x="12.5" y="14" width="7" height="6" rx="1" stroke="#3b5bdb" stroke-width="1.5" fill="none"/><path d="M13.5 14v-2.5a2.5 2.5 0 015 0V14" stroke="#3b5bdb" stroke-width="1.5" stroke-linecap="round" fill="none"/><circle cx="16" cy="17" r="1" fill="#3b5bdb"/></svg>`;
 
@@ -50,7 +52,7 @@ export function Layout({ children }: { children: Child }) {
           <meta name="twitter:title" content="FGP (Fine-Grained Proxy)" />
           <meta name="twitter:description" content={FGP_DESCRIPTION} />
 
-          <link rel="stylesheet" href="/static/styles.css" />
+          <link rel="stylesheet" href={assetUrl("/static/styles.css")} />
         </head>
         <body class="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 min-h-screen antialiased">
           <a

--- a/src/ui/logs-page.tsx
+++ b/src/ui/logs-page.tsx
@@ -1,4 +1,5 @@
 import { FgpLogo, Layout } from "./layout.tsx";
+import { assetUrl } from "./asset-version.ts";
 
 export function LogsPage() {
   return (
@@ -269,7 +270,7 @@ export function LogsPage() {
         </section>
       </main>
 
-      <script defer src="/static/logs-client.js"></script>
+      <script defer src={assetUrl("/static/logs-client.js")}></script>
     </Layout>
   );
 }

--- a/src/ui/tailwind.css
+++ b/src/ui/tailwind.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  /* Le gabarit d'alerte pose display:flex sur des blocs pilotes par l'attribut `hidden`.
+     Sans cette regle ils resteraient visibles : une declaration d'auteur bat toujours celle
+     de l'agent utilisateur, et le preflight ne redeclare pas [hidden]. */
+  [hidden] {
+    display: none !important;
+  }
+}

--- a/tests/testi/endpoints.test.ts
+++ b/tests/testi/endpoints.test.ts
@@ -44,14 +44,14 @@ Deno.test({
 });
 
 Deno.test({
-  name: 'AC-10.3.1: GET / contains <script defer src="/static/client.js"',
+  name: 'AC-10.3.1: GET / contains <script defer src="/static/client.js" versionne',
   fn: async () => {
     const res = await app.request("/");
     const body = await res.text();
 
     assertEquals(res.status, 200);
     assertEquals(
-      body.includes('<script defer src="/static/client.js"'),
+      body.includes('<script defer src="/static/client.js?v='),
       true,
     );
   },

--- a/tests/testi/endpoints.test.ts
+++ b/tests/testi/endpoints.test.ts
@@ -50,10 +50,14 @@ Deno.test({
     const body = await res.text();
 
     assertEquals(res.status, 200);
-    assertEquals(
-      body.includes('<script defer src="/static/client.js?v='),
-      true,
-    );
+    const match = body.match(/<script defer src="(\/static\/client\.js\?v=[^"]+)"/);
+    assertEquals(match !== null, true);
+
+    // L'URL versionnee doit etre servie : sans cette requete, un service statique qui
+    // rejetterait la query casserait tous les assets d'un coup sans faire echouer le test.
+    const asset = await app.request(match![1]);
+    assertEquals(asset.status, 200);
+    await asset.body?.cancel();
   },
   sanitizeOps: false,
   sanitizeResources: false,


### PR DESCRIPTION
Sept retours après usage réel. Six d'entre eux avaient une cause unique, et ce n'était pas celle qu'on croyait.

## La cause réelle : le cache navigateur

Cinq défauts de rendu et l'inertie des liens vers la documentation s'expliquaient par un `static/` périmé. Le premier diagnostic concluait à un problème de déploiement. **Vérification faite sur l'instance publique, c'est faux** : `version.txt` retourne le SHA du dernier commit, la feuille contient bien `height:2.375rem` et `align-items:flex-end`, le bundle porte `data-goto-doc` et `returnLabel`.

La cause est que `/static/*` est servi en `max-age=86400` avec des **noms de fichiers stables**. Toute personne ayant ouvert la page dans les 24 heures précédant un déploiement continue de recevoir l'ancien CSS et l'ancien JS, avec un HTML neuf. C'est exactement l'état que le designer reproduisait en supprimant quatre règles de la feuille.

Les trois assets sont désormais suffixés par le SHA du build, déjà résolu dans `static/version.txt`. Sans ce correctif, chaque lot laisse les utilisateurs sur une version périmée pendant 24 heures, et le problème se reproduit indéfiniment.

## Le correctif de conception reste nécessaire

Un cache-busting empêche la désynchronisation d'arriver, pas la mise en page de s'effondrer quand elle arrive.

Le lot précédent avait retiré le `py-*` des boutons au profit d'une classe de hauteur unique à valeur arbitraire, créant un **point de défaillance unique** : la disparition de quatre règles suffisait à faire tomber cinq contrôles à 20 px et à en étirer un à 58, soit 1,53 fois la hauteur de son champ.

Défense en profondeur à trois niveaux : le padding revient comme hauteur intrinsèque, les contrôles sans bordure visible reçoivent `border border-transparent` pour compenser celle du champ voisin, et l'ancrage se déclare **sur l'élément** avec `self-end` plutôt que sur le parent avec `items-end`. Cette dernière pièce est celle qui porte la robustesse : avec le padding seul et un parent en `stretch`, on retombe à 58 px. `items-end` n'existe plus dans les sources.

## Deux contrôles qui manquaient à l'inventaire

Les boutons de copie du bloc résultat **recopiaient à la main** leur classe partagée sans sa hauteur, et se retrouvaient 4 px plus courts que leur voisin. Et `#btn-byok-copy`, en `text-xs`, demandait un padding différent : il ne devait ses 38 px qu'à l'étirement de son voisin. Le designer en a tiré une formule vérifiée au banc d'essai, `padding = (échelle - interligne - 2) / 2`, qui remplace ses valeurs fixes posées en supposant un interligne constant.

C'est le troisième inventaire de contrôles qui se révèle incomplet sur ce projet.

## Les deux autres points

La jauge de diversité faisait 309 px pour un champ de 191, soit exactement la largeur des deux boutons en trop, parce qu'elle était sœur de la rangée au lieu de l'être du champ. Elle suit désormais le champ dans les deux dispositions.

Les six encadrés d'alerte avaient six traitements différents. Gabarit unique où seule la rampe de couleur change, la couleur n'étant jamais seule porteuse de sens. Le gabarit imposant `display:flex`, l'attribut `hidden` devient inconditionnel via une règle de couche de base : c'est la bonne réponse générale au conflit déjà rencontré sur le badge de clé, et elle **remplace** la règle d'évitement qui interdisait les classes de display sur ces éléments, devenue intenable.

## Le test qui aurait attrapé la régression

Une review de code ne pouvait pas voir ces cinq défauts, le source était correct et les mesures justes sur un build frais. Ce qui les attrape : **mesurer une seconde fois après suppression des règles de la feuille compilée**. Avec le correctif, les hauteurs tiennent. Ajouté à la recette.

## Mesures

Nominal à 375 px : les sept paires à zéro écart, jauge 190,75 pour un champ de 190,75. Repli à 346 px : 280 pour 280, boutons groupés sous le champ, pas de scroll horizontal.

État dégradé après correctif : plus rien à 20 ni à 58 px, et plus aucune hauteur qui dépende d'un voisin. Seuls subsistent 1,5 px sur les deux `select`, documentés en tolérance : leur boîte de contenu dérive de la police et non de la line-height, aucun cran Tailwind ne tombe sur 38, et fermer l'écart demanderait un padding calculé pour une police donnée, soit précisément la fragilité que ce lot supprime.

`deno task verify` vert, 578 tests.

## Reste ouvert

`version.txt` vaut `git rev-parse --short HEAD`, donc un déploiement depuis un arbre sale garde le même SHA et ne casse pas le cache. Et `max-age=86400` pourrait passer à `immutable` maintenant que les URLs sont versionnées.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added versioned URLs for JavaScript and CSS assets to improve cache refreshes after updates.
  - Added consistent informational, caution, and error alert styles with supporting icons.
  - Improved display and layout of configuration controls, warnings, and action buttons.

- **Bug Fixes**
  - Corrected hidden alert behavior so dismissed messages remain hidden.
  - Improved error banner updates without replacing the surrounding alert structure.

- **Tests**
  - Updated endpoint coverage to verify versioned client script URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->