### PR TITLE
docs: synchronisation documentaire du lot securite et exposition des codes d'erreur

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ Beaucoup d'APIs ne proposent pas de tokens a granularite fine. FGP permet de gen
 | `SCALINGO_API_URL` | non | URL de l'API Scalingo | `https://api.osc-fr1.scalingo.com` |
 | `SCALINGO_AUTH_URL` | non | URL du service auth Scalingo | `https://auth.scalingo.com` |
 | `FGP_GITHUB_REPO` | non | Repo GitHub (`owner/name`) pour la resolution du SHA de build (utile pour les forks sans git) | auto-detecte via git remote ou `lsagetlethias/fine-grained-proxy` |
+| `FGP_EGRESS_ALLOW_PRIVATE` | non | **Interrupteur de developpement.** `1` desactive le refus des destinations non publiques. Voir l'avertissement ci-dessous. | off |
+| `FGP_TRUSTED_PROXY_HOPS` | non | Nombre de proxys de confiance en amont, pour lire `X-Forwarded-For`. `0` ignore l'en-tete et utilise l'adresse du pair | `0` |
 | `FGP_LOGS_ENABLED` | non | Kill switch feature `/logs` (`1` active les routes `/logs` + `/logs/stream` et la capture, sinon 404) | off |
 | `FGP_LOGS_BUFFER_NETWORK` | non | Taille du ring buffer network par blob | `50` |
 | `FGP_LOGS_BUFFER_DETAILED` | non | Taille du ring buffer detailed (body chiffre) par blob | `10` |
 | `FGP_LOGS_INACTIVITY_MIN` | non | Minutes d'inactivite avant purge du buffer d'un blob | `10` |
 | `FGP_LOGS_DETAILED_MAX_KB` | non | Taille max du body capture en detailed (KB) avant troncature | `32` |
+
+> **`FGP_EGRESS_ALLOW_PRIVATE=1` ne doit jamais etre actif en production.**
+> Il desactive la classification des destinations, donc la garantie G1 de la politique de sortie. L'instance redevient exactement la SSRF non authentifiee que cette politique corrige : n'importe qui peut lui faire emettre des requetes vers le reseau prive de l'hebergeur, service de metadonnees compris, et en recuperer le corps de reponse. Il existe pour le developpement local et la suite de tests, rien d'autre. Le serveur ecrit un avertissement au demarrage quand il est actif.
 
 ### Lancer en dev
 
@@ -113,7 +118,6 @@ Retourne la configuration complete avec le token redacte. Utile pour inspecter o
 | `/api/generate` | POST | Generation d'URL FGP. Champ `key` optionnel pour fournir sa propre cle client (24 a 256 caracteres) |
 | `/api/list-apps` | POST | Helper Scalingo : listing des apps |
 | `/api/list-addons` | POST | Helper Scalingo : listing des bases de donnees d'une app |
-| `/api/test-scope` | POST | Test scope matching : verifie si methode + path + body est autorise par des scopes |
 | `/api/test-proxy` | POST | Test end-to-end : appel reel vers l'API cible avec verification scopes et body filters |
 | `/api/decode` | POST | Decode un blob chiffre avec sa cle, retourne la config (token redacte) |
 | `/api/share/encode` | POST | Encode une config (target, auth, scopes, TTL, body filters) en string gzip+base64url pour partage |
@@ -153,6 +157,17 @@ Quatre modes string (blob v2/v3) et deux modes structures (blob v4, champ `auth`
 | `{ type: "scalingo-addon" }` | AuthSpec | Token d'addon Scalingo obtenu en trois temps et renouvele automatiquement (1h). Affiche « Scalingo Database API » dans l'UI |
 
 Les blobs v2 et v3 restent lisibles sans changement : le passage en v4 n'intervient que si `auth` est un objet. Voir [ADR 0008](docs/adr/0008-auth-structuree-blob-v4.md).
+
+### Politique de sortie
+
+Toute requete sortante emise par FGP passe par un point de sortie unique qui applique quatre garanties (ADR-0009) : destination publique uniquement, chemin autorise egal au chemin emis, authentification issue du blob et jamais de l'appelant, et un etat de la query dit explicitement par l'outillage.
+
+Consequences visibles :
+
+- Les cibles non publiques (loopback, reseaux prives, link-local, metadonnees) sont refusees en 403 `target_forbidden`.
+- Les redirections ne sont plus suivies : un 3xx amont est forwarde tel quel.
+- Les en-tetes `Authorization` et `Cookie` de l'appelant ne sont plus transmis. Pour envoyer un `Authorization` fixe a l'upstream, le declarer dans l'AuthSpec `headers` du blob (v4).
+- **Les parametres de query ne sont pas contraints par les scopes.** Un blob scope sur `/v1/items` accepte `/v1/items?action=delete`. C'est une dette datee, pas un non-goal : voir `docs/specs.md` section 18.4.
 
 ### Scopes METHOD:PATH + body filters
 
@@ -232,7 +247,7 @@ Feature opt-in gatee par `FGP_LOGS_ENABLED=1`. Activee par blob via le champ `lo
 - [Criteres d'acceptation](docs/acceptance-criteria.md)
 - [Limites fonctionnelles body filters et auth structuree](docs/limits.md)
 - [Changelog](docs/changelog.md)
-- [Architecture Decision Records](docs/adr/)
+- [Architecture Decision Records](docs/adr/), dont [ADR-0009 politique de sortie](docs/adr/0009-politique-de-sortie-du-proxy.md) et [ADR-0010 limites de ressources](docs/adr/0010-politique-limites-ressources.md)
 - [Guide deploiement Deno Deploy](docs/deno-deploy.md)
 - [Guide deploiement Scalingo](docs/scalingo-deploy.md)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 4 septembre 2026
+
+- **Breaking** : `POST /api/test-scope` est supprimé. L'interface testait déjà les scopes dans le navigateur, la route serveur n'avait aucun appelant
+- **Breaking** : les en-têtes `Authorization` et `Cookie` de l'appelant ne sont plus transmis à la cible. Pour en envoyer un fixe, déclarez-le dans les headers multiples du blob
+- **Breaking** : les regex des body filters sont désormais ancrées. Un filtre `main` n'autorise plus `not-main-at-all`, c'était un contournement de scope
+- **Breaking** : les regex du blob suivent un dialecte restreint, sans groupe quantifié ni lookaround. Un blob concerné renvoie `unsupported_regex` et doit être régénéré
+- **Breaking** : une regex ne teste plus que les valeurs jusqu'à 128 caractères, contre 1000 avant. Au-delà, utilisez un pattern glob
+- **Breaking** : un filtre `any` sur un objet ou un tableau est refusé. La comparaison dépendait de l'ordre des clés du client, donc du hasard
+- **Breaking** : un `?` dans un pattern de scope est refusé à la génération (`invalid_scope`). Il produisait un scope mort qui ne contraignait rien
+- **Breaking** : les cibles non publiques sont refusées (`target_forbidden`) : boucle locale, réseaux privés, link-local, métadonnées cloud
+- **Breaking** : les redirections de l'API cible ne sont plus suivies. Un 3xx vous est transmis tel quel, avec son `Location`
+- **Breaking** : les corps de requête trop volumineux renvoient `payload_too_large` (413). Le streaming à travers le proxy reste sans plafond
+- **Les paramètres de query ne sont pas contraints par les scopes** : un blob autorisé sur `/v1/items` accepte `/v1/items?action=delete`, en attendant la feature
+- Le testeur de scopes de l'interface ne ment plus : il refusait des requêtes que le proxy acceptait. Une seule fonction d'autorisation, partagée avec le proxy
+- Nouvelle variable `FGP_TRUSTED_PROXY_HOPS` pour lire `X-Forwarded-For` derrière un proxy de confiance. Sans elle, les logs utilisent l'adresse du pair
+- Nouvelle variable `FGP_EGRESS_ALLOW_PRIVATE`, réservée au développement : l'activer en production rouvre l'accès au réseau privé de votre hébergeur
+- La limitation de débit est documentée côté opérateur, dans les guides Deno Deploy et Scalingo. FGP n'en implémente pas, un limiteur en mémoire serait inopérant sur Deploy
+- Les assets de l'interface portent une empreinte de contenu : plus de CSS ni de JavaScript périmé après une mise à jour
+
 ## 3 septembre 2026
 
 - Nouveau mode d'auth « Headers multiples » : envoyez plusieurs headers d'authentification vers l'API cible (par exemple `X-API-Key` et `X-Client-Id`) depuis une seule URL FGP

--- a/docs/deno-deploy.md
+++ b/docs/deno-deploy.md
@@ -44,10 +44,31 @@ Configurer dans la console Deno Deploy ([console.deno.com](https://console.deno.
 | `SCALINGO_API_URL` | Non | URL API Scalingo (defaut: `https://api.osc-fr1.scalingo.com`) |
 | `SCALINGO_AUTH_URL` | Non | URL auth Scalingo (defaut: `https://auth.scalingo.com`) |
 | `FGP_GITHUB_REPO` | Non | Repo GitHub `owner/name` pour le SHA de build (defaut: `lsagetlethias/fine-grained-proxy`) |
+| `FGP_EGRESS_ALLOW_PRIVATE` | Non | **Ne jamais activer en production.** Voir l'avertissement ci-dessous |
+| `FGP_TRUSTED_PROXY_HOPS` | Non | Nombre de proxys de confiance en amont pour lire `X-Forwarded-For` (defaut `0`, l'en-tete est ignore) |
 
 `PORT` n'est pas necessaire (gere par Deno Deploy).
 
 > **SHA de build** : git n'est pas disponible sur Deno Deploy. Le script `build:version` fallback sur l'API GitHub pour resoudre le SHA du dernier commit. Si vous deployez un fork, positionnez `FGP_GITHUB_REPO` sur votre repo pour que le lien dans le footer pointe au bon endroit.
+
+> **`FGP_EGRESS_ALLOW_PRIVATE=1` annule la garantie de destination.**
+> Il desactive le refus des adresses non publiques. Une instance qui tourne avec cet interrupteur redevient une SSRF non authentifiee : n'importe qui lui fait emettre des requetes vers le reseau prive de l'hebergeur, service de metadonnees compris, et en recupere la reponse. Il existe pour le developpement local et les tests. Sur une instance publique, il ne doit pas etre positionne.
+
+## Limitation de debit
+
+**FGP n'implemente aucune limitation de debit, et c'est un choix documente** (ADR-0010). Un limiteur en memoire du processus est quasi inoperant sur Deno Deploy : l'etat est par isolate, les isolates sont ephemeres, et les requetes se repartissent entre eux. Livrer un limiteur qui ne fonctionne que sur une cible de deploiement sur deux donnerait une fausse couverture, ce qui est pire que pas de couverture.
+
+**La borne doit donc etre posee devant l'instance**, dans un CDN ou un WAF.
+
+L'ordre de grandeur qui justifie de ne pas s'en passer : avant les correctifs de l'ADR-0010, **1 900 requetes suffisaient a epuiser les 20 heures de CPU mensuelles du plan gratuit**. Les correctifs ont supprime le cout unitaire aberrant, ils n'ont pas supprime le besoin d'une borne sur le nombre de requetes. Une vingtaine d'heures d'inondation suffit toujours a consommer le quota mensuel.
+
+A configurer en frontal :
+
+- une limite par IP sur `/api/*`, ou vivent les endpoints de generation et les helpers ;
+- une limite plus large sur la route proxy `/{blob}/*`, qui porte le trafic utile ;
+- un plafond de taille de requete, en complement des plafonds applicatifs.
+
+**Le filtrage d'egress au niveau reseau** est par ailleurs la seule defense reelle contre le rebinding DNS, que la politique de sortie ne ferme pas (specs section 18.2). Si votre frontal ou votre reseau le permet, restreindre les destinations sortantes de l'instance complete utilement la politique applicative.
 
 ## Deployer via CLI
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -128,6 +128,16 @@ Un AND sur zero conditions est trivialement vrai (vacuous truth). Ca revient a u
 | Addons par AuthSpec `scalingo-addon` | exactement 1 | validation AuthSpec dans `blob.ts` |
 | Longueur `app` et `addonId` | 64 chars max | validation AuthSpec dans `blob.ts` |
 | Longueur clé client fournie | 24 à 256 chars | `POST /api/generate` |
+| Valeur testée par une regex | 128 chars max | matching, ADR-0010 |
+| Valeurs `regex` par blob | 4 max | validation blob, ADR-0010 |
+| Éléments d'un `and` | 8 max | validation blob, ADR-0010 |
+| `ObjectValue` par blob, toutes portées | 256 max | validation blob, ADR-0010 |
+| Source d'une regex | 200 chars max | validation blob |
+| Quantificateurs par regex | 3 max | validation blob, ADR-0010 |
+| Sortie de décompression | 128 Ko | blob et partage, ADR-0010 |
+| Champ `encoded` de `/api/share/decode` | 8192 chars | schéma Zod |
+| Corps bufferisé sur le proxy | 512 Ko | uniquement si body filter ou capture detailed |
+| Corps sur `/api/*` | 64 Ko par défaut | 8 Ko decode, 16 Ko share/decode, 4 Ko helpers Scalingo |
 | `not(wildcard)` | interdit | `isValidObjectValue` |
 | `not(not(...))` | interdit | `isValidObjectValue` |
 | `and([])` | interdit | `isValidObjectValue` |
@@ -201,3 +211,63 @@ Le maximum est une borne défensive : la clé transite dans le header `X-FGP-Key
 **Pourquoi limiter** : une clé mutualisée entre plusieurs blobs mutualise le risque. Si elle fuite ou est cassée, tous les blobs générés avec elle deviennent déchiffrables d'un coup, y compris ceux créés avant la fuite. C'est le prix de la commodité en CI, et il doit être affiché explicitement dans l'UI.
 
 **Impact sans limite** : une clé de 6 caractères rendrait le chiffrement du blob décoratif. Un attaquant qui capte une URL FGP la casse hors ligne, récupère le token upstream en clair, et le proxy n'a servi à rien.
+
+---
+
+## 11. Limites de ressources (ADR-0010)
+
+Les limites des sections précédentes ont été posées une par une, pour des raisons fonctionnelles. Celles-ci répondent à un critère unique et mesuré.
+
+**Le critère : aucune primitive optionnelle ne doit coûter plus cher que la dérivation de clé obligatoire déjà présente sur le chemin.**
+
+La dérivation PBKDF2 est incompressible, elle est nécessaire pour déchiffrer et elle coûte 11,6 ms. Elle fixe donc le plancher de coût d'une requête proxy. Tout ce qui vient en plus (matching, décompression, parsing) doit rester sous cet ordre de grandeur, sinon la fonctionnalité optionnelle devient le coût dominant de l'instance. Ce critère remplace les nombres ronds : chaque plafond ci-dessous est calibré pour que son pire cas mesuré tienne dans ce budget.
+
+### 11.1 Regex : trois couches, pas une
+
+**Valeur testée : 128 caractères max** (auparavant 1 000). C'est la couche porteuse, parce qu'elle ne dépend d'aucune analyse du motif et ne peut donc pas se tromper. Le backtracking est exponentiel ou polynomial en la longueur de l'entrée : le motif `^a*a*a*b$` coûte 181,9 ms sur 1 000 caractères, 6,78 ms sur 256, et 2,54 ms sur 128. Une valeur plus longue doit être filtrée par `stringwildcard`, mesuré sur jusqu'à 8 000 caractères.
+
+**Dialecte restreint**, validé à la génération avec un message actionnable, et au déchiffrement avec un refus du blob :
+
+- source de 200 caractères maximum ;
+- **aucun quantificateur appliqué à un groupe** : `(...)+`, `(?:...)*`, `(...){2,}` sont refusés. C'est la règle qui tue `^(a+)+$`, mesuré à 3 248 ms sur 29 caractères et 37 900 ms sur 31 ;
+- ni backréférence `\1` à `\9`, ni lookaround ;
+- `{n,m}` avec `m` inférieur ou égal à 100 ;
+- 3 quantificateurs au maximum. Le pire cas construit à 3 quantificateurs tient dans le budget, celui à 4 non (82,6 ms), celui à 5 encore moins (2 209 ms).
+
+**4 valeurs `regex` par blob**, toutes portées confondues. Quatre évaluations à 2,54 ms font 10,2 ms, soit exactement le budget.
+
+Cette dernière couche est une heuristique, donc jamais seule : un motif qui passerait au travers de l'analyse retomberait sur les deux autres.
+
+### 11.2 Ancrage des regex : une correction de faille, pas de performance
+
+**L'évaluation est ancrée** : le moteur reçoit toujours `^(?:source)$`.
+
+Auparavant, `{"type":"regex","value":"main"}` autorisait `not-main-at-all`, parce que `RegExp.test` fait du sous-chaîne. Un prédicat de permission qui matche en sous-chaîne est un contournement de scope qui attend son heure.
+
+L'ancrage par enveloppement ne resserre jamais dans le mauvais sens : un ancien blob devient plus strict, jamais plus permissif.
+
+### 11.3 `any` restreint aux valeurs scalaires
+
+`any` n'accepte plus que `string`, `number`, `boolean` et `null`. Refusé à la génération et au déchiffrement.
+
+Deux raisons, et la seconde est la vraie. Le coût : 1 280 comparaisons sur un sous-arbre de 770 Ko font 2 956 ms, contre 0,16 ms sur des scalaires. **La correction** : la comparaison était déjà cassée sur les objets. Elle repose sur `JSON.stringify`, qui dépend de l'ordre d'insertion des clés, et cet ordre vient du sérialiseur de l'appelant. `JSON.stringify({a:1,b:2}) === JSON.stringify({b:2,a:1})` vaut `false`. Un filtre `any` sur un objet autorisait ou refusait selon l'ordre dans lequel le client avait écrit son JSON. Ce n'est pas un prédicat de permission, c'est un tirage.
+
+### 11.4 Décompression bornée
+
+**128 Ko en sortie**, pour le blob comme pour le partage. Le ciphertext d'un blob vaut au plus 3 044 octets, donc 128 Ko autorisent un ratio de 42:1, largement au-dessus des 10 à 15:1 constatés sur du JSON de configuration répétitif, tout en coupant d'un facteur 24 le ratio gzip maximal mesuré à 1 029:1. Un blob dont la sortie dépasse 128 Ko ne peut pas être une configuration valide.
+
+Effet sur `/api/share/decode` : 265 Ko d'entrée pour 320 Mo de RSS deviennent 8 Ko d'entrée pour 128 Ko de sortie. L'amplification passe de 1 200:1 à 16:1.
+
+### 11.5 Taille des corps de requête
+
+**`/api/*` : 64 Ko par défaut**, resserré par route (8 Ko sur `/api/decode`, 16 Ko sur `/api/share/decode`, 4 Ko sur les deux helpers Scalingo). Dépassement : 413 `payload_too_large`.
+
+**Jamais sur `*`.** La route proxy transmet le corps en streaming ; un plafond global le mettrait en tampon, casserait les uploads volumineux légitimes à travers le proxy et introduirait précisément la consommation mémoire qu'on cherche à éviter. Montage sur liste explicite, comme pour les en-têtes de sécurité.
+
+**Corps bufferisé sur le proxy : 512 Ko**, et **uniquement quand un body filter ou la capture detailed est actif**. `JSON.parse` de 337 Ko coûte 0,92 ms, donc 512 Ko coûtent environ 1,4 ms, un ordre de grandeur sous les 11,6 ms de la dérivation obligatoire.
+
+**Non-régression à protéger** : sans body filter et sans capture detailed, le corps n'est jamais bufferisé, il est transmis en flux, et le plafond ne s'applique pas. Les gros uploads à travers le proxy continuent de passer. C'est une propriété du proxy transparent qu'il ne faut pas perdre en posant la limite au mauvais endroit.
+
+### 11.6 Ce que ces limites ne font pas
+
+Elles bornent le **coût d'une requête**, jamais le **nombre de requêtes**. La limitation de débit est hors de l'application, pour une raison écrite dans les specs §18.6 et dans les guides de déploiement.

--- a/docs/review/ac-coverage-v4.md
+++ b/docs/review/ac-coverage-v4.md
@@ -161,6 +161,8 @@ Convention appliquee : virgule dans les noms de test (ils portent deja le deux-p
 | AC-40.15 | Pas de `Link` sur une reponse forwardee | `llms-txt` (testi) | **OK** |
 | AC-40.16 | Paths a un seul segment, comportement observe | `llms-txt` (testi, x2) | **OK** |
 | AC-40.17 | `/llms.txt` durci | `llms-txt` (testi) + `security-headers` | **OK** |
+| AC-40.18 | Les 15 codes d'erreur du proxy sont dans `/llms.txt` | `llms-txt` (testu) | **OK** |
+| AC-40.19 | Les 3 non-garanties de sortie sont dites dans `/llms.txt` | `llms-txt` (testu) | **OK** |
 
 ## AC-41 : Headers de securite et transparence
 

--- a/docs/scalingo-deploy.md
+++ b/docs/scalingo-deploy.md
@@ -46,6 +46,17 @@ scalingo --app fgp-proxy env-set SCALINGO_AUTH_URL="https://auth.scalingo.com"
 
 `PORT` est automatiquement fourni par Scalingo.
 
+Deux variables optionnelles mais importantes :
+
+```bash
+# Nombre de proxys de confiance en amont, pour que les logs voient la vraie IP.
+# Defaut 0 : X-Forwarded-For est ignore et l'adresse du pair est utilisee.
+scalingo --app fgp-proxy env-set FGP_TRUSTED_PROXY_HOPS="1"
+```
+
+> **Ne jamais positionner `FGP_EGRESS_ALLOW_PRIVATE=1` sur une instance publique.**
+> Cet interrupteur desactive le refus des destinations non publiques, donc la garantie de destination de la politique de sortie. L'instance redevient une SSRF non authentifiee : n'importe qui lui fait emettre des requetes vers le reseau prive de l'hebergeur, service de metadonnees compris, et en recupere la reponse. Il existe pour le developpement local et les tests.
+
 ### 5. Optionnel : fixer la version Deno
 
 Creer un fichier `.deno-version` a la racine :
@@ -80,6 +91,24 @@ Le log de build doit montrer le build des assets avant le demarrage du dyno :
 curl https://fgp-proxy.osc-fr1.scalingo.io/healthz
 # {"status":"ok"}
 ```
+
+## Limitation de debit
+
+**FGP n'implemente aucune limitation de debit** (ADR-0010). La decision tient a la portabilite : un limiteur en memoire est inoperant sur Deno Deploy, ou l'etat est par isolate. Livrer un limiteur efficace sur une cible sur deux donnerait une fausse couverture.
+
+**En auto-hebergement, la situation est plus favorable** : le processus est unique et durable, donc un `limit_req` nginx en frontal fonctionne reellement, et un limiteur en processus fonctionnerait aussi si le besoin se confirmait.
+
+Configuration recommandee en frontal, sur le reverse proxy qui expose l'app :
+
+- `limit_req` par IP sur `/api/*` ;
+- une zone plus large sur la route proxy `/{blob}/*` ;
+- un plafond de taille de corps, en complement des plafonds applicatifs.
+
+**Une note qui compte pour cette cible** : sur un processus unique, une requete emballee n'est pas une requete lente, c'est une **indisponibilite totale**. Le runtime est mono-thread, toute milliseconde de CPU synchrone consommee par une requete est une milliseconde pendant laquelle aucune autre n'avance. Les plafonds de l'ADR-0010 bornent le cout d'une requete precisement pour cette raison, mais ils ne bornent pas leur nombre.
+
+Ordre de grandeur : avant ces correctifs, 1 900 requetes suffisaient a epuiser 20 heures de CPU.
+
+**Le filtrage d'egress au niveau reseau** complete par ailleurs la politique de sortie, et reste la seule defense reelle contre le rebinding DNS (specs section 18.2).
 
 ## Risques et limites
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -562,12 +562,17 @@ Les messages des erreurs FGP (`X-FGP-Source: proxy`) sont **volontairement gén�
 | **401 Unauthorized** | Déchiffrement échoué (clé invalide ou blob corrompu) | `{"error": "invalid_credentials", "message": "Unable to decrypt token"}` |
 | **403 Forbidden** | La méthode/path/body ne matchent aucun scope | `{"error": "scope_denied", "message": "Insufficient permissions for this action"}` |
 | **403 Forbidden** | Body filters requis mais content-type non JSON | `{"error": "scope_denied", "message": "Body filters require application/json content type"}` |
+| **400 Bad Request** | Le blob porte une regex hors du dialecte autorisé (ADR-0010) | `{"error": "unsupported_regex", "message": "..."}` |
+| **403 Forbidden** | La cible du blob n'est pas une destination publique (ADR-0009) | `{"error": "target_forbidden", "message": "Target is not reachable by policy"}` |
+| **413 Payload Too Large** | Corps de requête trop volumineux pour être inspecté, quand un body filter ou la capture detailed est actif | `{"error": "payload_too_large", "message": "Request body is too large to inspect"}` |
 | **410 Gone** | Le TTL du blob est expiré | `{"error": "token_expired", "message": "This token has expired"}` |
 | **414 URI Too Long** | Blob base64url > 4 KB | `{"error": "blob_too_large", "message": "Encrypted blob exceeds maximum size"}` |
 | **500 Internal Server Error** | Exception non catchée dans le proxy (bug FGP) | `{"error": "internal_error", "message": "Internal proxy error"}` |
 | **502 Bad Gateway** | L'API cible est injoignable (fetch throw : DNS, timeout, connexion refusée, TLS) | `{"error": "upstream_unreachable", "message": "Target API is unreachable"}` |
 | **502 Bad Gateway** | Mode `scalingo-exchange` : l'échange du token de compte contre un bearer a échoué | `{"error": "auth_exchange_failed", "message": "Unable to exchange Scalingo token"}` |
 | **502 Bad Gateway** | Mode `scalingo-addon` : FGP n'a pas pu obtenir de token d'addon (exchange refusé, API Scalingo en erreur ou injoignable) | `{"error": "auth_addon_failed", "message": "Unable to obtain addon token"}` |
+
+`unsupported_regex` est volontairement distinct de `invalid_credentials`. Un blob dont une regex sort du dialecte est parfaitement déchiffrable : le signaler comme un problème d'identifiants enverrait son porteur vérifier sa clé, ce qui est un diagnostic mensonger. Il doit régénérer son blob, pas retrouver sa clé.
 
 Trois 502 sont légitimes côté proxy, et elles ne se recouvrent pas :
 
@@ -585,6 +590,14 @@ Les endpoints internes du proxy qui tapent eux-mêmes des APIs externes (ex : `P
 
 - Échec réseau (fetch throw) → 502 `upstream_unreachable` + `X-FGP-Source: proxy`.
 - Échec d'exchange token (pour `list-apps` et `list-addons`) → 401 `token_exchange_failed` + `X-FGP-Source: proxy`.
+
+Trois codes supplémentaires apparaissent sur ces endpoints. Les deux premiers leur sont propres, ils n'existent pas sur la route proxy. Le troisième vit sur les deux surfaces, avec un plafond différent de chaque côté (§18.5) :
+
+| Status | Code | Endpoint | Condition |
+|--------|------|----------|-----------|
+| 400 | `invalid_target` | `/api/generate`, `/api/list-apps`, `/api/list-addons` | La cible ne respecte pas la forme exigée, ou son hôte n'est pas public (ADR-0009) |
+| 400 | `invalid_scope` | `/api/generate` | Un pattern de scope porte un `?`, ce que le langage de scopes ne contraint pas (cf. §18.4) |
+| 413 | `payload_too_large` | tout `/api/*` | Corps de requête au-delà du plafond de la route |
 
 Ne pas confondre `token_exchange_failed` (401, endpoints internes `/api/list-apps` et `/api/list-addons`) avec `auth_exchange_failed` (502, proxy principal en mode `scalingo-exchange`). Les deux décrivent un échange de token Scalingo qui a échoué, mais ils ne s'adressent pas au même public : le premier dit à l'utilisateur de l'UI que **son** token est mauvais, au moment où il le saisit, et il peut le corriger. Le second dit au consommateur d'une URL FGP que le proxy n'a pas pu s'authentifier pour lui, ce qui n'est pas de son ressort et ne se corrige pas côté client. Deux publics, deux statuts, deux codes.
 
@@ -607,11 +620,12 @@ Le proxy vérifie dans cet ordre, et renvoie la première erreur rencontrée :
 6. Validité du mode d'auth → 400 `invalid_auth_mode` (`X-FGP-Source: proxy`)
 7. Parsing du body (si body filters requis) → 400 `invalid_body` ou 403 `scope_denied` (`X-FGP-Source: proxy`)
 8. Vérification du scope (méthode + path + body) → 403 `scope_denied` (`X-FGP-Source: proxy`)
-9. Obtention des credentials upstream → 502 `auth_exchange_failed` en mode `scalingo-exchange`, 502 `auth_addon_failed` en mode `scalingo-addon` (`X-FGP-Source: proxy`)
-10. Forward vers l'API cible :
+9. Application de la politique de sortie sur la cible du blob (§18) → 403 `target_forbidden` (`X-FGP-Source: proxy`)
+10. Obtention des credentials upstream → 502 `auth_exchange_failed` en mode `scalingo-exchange`, 502 `auth_addon_failed` en mode `scalingo-addon` (`X-FGP-Source: proxy`)
+11. Forward vers l'API cible :
     - Si `fetch` throw (réseau) → 502 `upstream_unreachable` (`X-FGP-Source: proxy`)
     - Sinon → status/body/headers upstream forwardés transparents (`X-FGP-Source: upstream`)
-11. Exception inattendue à n'importe quelle étape → 500 `internal_error` via `app.onError` (`X-FGP-Source: proxy`)
+12. Exception inattendue à n'importe quelle étape → 500 `internal_error` via `app.onError` (`X-FGP-Source: proxy`)
 
 L'obtention des credentials intervient **après** la vérification des scopes : un appelant hors scope ne doit jamais provoquer d'appel réseau vers Scalingo.
 
@@ -659,7 +673,6 @@ Le mode `scalingo-addon` ajoute un **second cache**, indépendant du premier, po
 | `/api/share/decode` | POST | Décode une configuration publique partageable |
 | `/api/list-apps` | POST | Helper Scalingo : listing des apps via token exchange |
 | `/api/list-addons` | POST | Helper Scalingo : listing des bases de données d'une app pour en sélectionner une (cf. §12.8) |
-| `/api/test-scope` | POST | Test de scopes : vérifie si une requête (méthode + path + body) est autorisée par un jeu de scopes |
 | `/api/test-proxy` | POST | Test end-to-end : rejoue une requête réelle vers l'API cible avec la configuration en cours |
 | `/api/openapi.json` | GET | Spec OpenAPI 3.0 (auto-générée depuis les schemas Zod) |
 | `/api/docs` | GET | Swagger UI (documentation interactive) |
@@ -798,11 +811,21 @@ Le comportement singleflight est inchangé : quand plusieurs requêtes concurren
 
 ### 11.2 Headers de requête
 
-Le proxy forward tous les headers du client vers la cible, sauf :
-- `X-FGP-Key` (consommé par le proxy, jamais transmis à la cible)
-- `Host` (supprimé pour laisser le runtime résoudre le bon host)
+Le proxy forward les headers du client vers la cible, **sauf cinq classes** retirées systématiquement (ADR-0009, garantie G3). Une denylist par classe, et non une allowlist, parce qu'il n'existe pas de liste finie d'en-têtes utiles à toutes les APIs : `Accept`, `Range`, `If-None-Match`, `Idempotency-Key` et l'infini des en-têtes propriétaires doivent passer.
 
-Le header `Authorization` (ou le header custom) est défini selon le mode d'auth.
+| Classe | En-têtes | Raison |
+|--------|----------|--------|
+| Contrôle FGP | `X-FGP-Key`, `X-FGP-Blob`, tout `X-FGP-*` | Appartiennent au protocole du proxy, pas à l'upstream |
+| Hop-by-hop | `Connection` et ceux qu'il nomme, `Keep-Alive`, `Proxy-*`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade` | Aucun proxy conforme ne les relaie (RFC 9110 §7.6.1). C'est aussi la matière première du request smuggling. |
+| Authentification de l'appelant | `Authorization`, `Cookie` | Voir ci-dessous |
+| Provenance | `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Real-IP`, `Forwarded` | FGP n'en pose aucun et n'en relaie aucun |
+| Host | `Host` | Supprimé pour laisser le runtime résoudre le bon hôte |
+
+**Pourquoi `Authorization` et `Cookie` de l'appelant ne passent plus.** La promesse de FGP est que l'appelant ne détient pas le credential de l'API cible. Laisser l'appelant poser son propre `Authorization` sur une requête dont le mode d'auth ne l'écrase pas (`header:{name}`, mode `headers`) permet d'atteindre l'upstream avec une identité que le blob n'a jamais accordée, sur une API qui accepte plusieurs schémas d'authentification. C'est une escalade de privilège qui contourne entièrement le modèle de scopes.
+
+**La porte de sortie légitime existe déjà** : qui a besoin d'envoyer un `Authorization` fixe à l'upstream le déclare dans l'AuthSpec `headers` du blob (v4, §6.3). La valeur vit alors dans le blob, chiffrée, au lieu d'être posée par l'appelant. C'est précisément ce pour quoi l'ADR-0008 a été écrit.
+
+Ordre d'application : les headers d'auth issus du blob écrasent ceux de l'appelant, puis le strip passe en dernier et écrase tout.
 
 ### 11.3 Headers de réponse
 
@@ -885,44 +908,27 @@ Pour `not` et `and`, l'UI propose des sous-types (exact, glob, existe) pour comp
 
 ### 12.5 Test de scopes (UI)
 
-L'UI propose une section dépliable "Tester un scope" sous les body filters. Elle permet de vérifier en temps réel si une requête (méthode + path + body optionnel) est autorisée par les scopes configurés.
+L'UI propose une section dépliable "Tester un scope" sous les body filters. Elle permet de vérifier si une requête (méthode + path + body optionnel) est autorisée par les scopes configurés.
 
 #### Fonctionnement
 
 1. **Highlight temps réel** : à mesure que l'utilisateur tape un path et sélectionne une méthode, les scopes matchant sont mis en surbrillance visuellement (indicateurs ✓/✗ par scope).
-2. **Run** : un bouton "Tester" envoie la requête de test à l'API `POST /api/test-scope` pour un résultat détaillé incluant les body filters.
+2. **Évaluation locale** : le test s'exécute **dans le navigateur**, sur la même fonction d'autorisation que celle du proxy. Il n'y a pas d'appel réseau.
 3. **Body JSON** : un textarea JSON optionnel (affiché pour POST/PUT/PATCH) permet de tester les body filters.
 
-#### API `POST /api/test-scope`
+#### `POST /api/test-scope` est supprimé
 
-**Input** :
+**Changement de contrat public.** La route figurait dans l'OpenAPI, le README, ces specs et `/llms.txt`. Elle n'avait aucun appelant dans le produit : l'UI faisait déjà son test dans le navigateur en important directement la fonction d'autorisation. Maintenir une copie serveur d'une logique que le produit exécute côté client, c'était payer une surface d'attaque publique et non authentifiée pour zéro valeur (ADR-0010 D1).
 
-```json
-{
-  "method": "string",
-  "path": "string",
-  "scopes": "Scope[]",
-  "body": "unknown (optionnel)"
-}
-```
+Un intégrateur tiers qui l'aurait câblée doit migrer vers `POST /api/test-proxy`, qui teste la configuration de bout en bout, ou reproduire la vérification chez lui.
 
-**Output** :
+#### Une seule fonction d'autorisation
 
-```json
-{
-  "allowed": "boolean",
-  "results": [
-    {
-      "index": "number",
-      "scope": "Scope",
-      "matched": "boolean",
-      "methodMatch": "boolean",
-      "pathMatch": "boolean",
-      "bodyMatch": "boolean | null"
-    }
-  ]
-}
-```
+Le testeur de scopes **mentait**, et pas par accident de code : il possédait sa propre lecture des scopes, en parallèle de celle du proxy. Sur `/v1/items?action=delete`, il répondait « Accès refusé » là où la production répondait 200. Un outil de vérification qui se trompe dans le sens permissif est pire que pas d'outil.
+
+Le correctif est structurel : **une seule fonction d'autorisation**, exportée par `src/middleware/scopes.ts`, appelée par le proxy et par le highlight client. Elle prend le chemin brut avec sa query éventuelle, applique la règle des deux formes (§18.3), et retourne un verdict dont un champ indique si la query est contrainte. Trois lectures des scopes ne peuvent pas rester d'accord dans le temps, une seule ne peut pas diverger.
+
+Ce champ vaut aujourd'hui toujours « query non contrainte » (§18.4). L'UI doit le refléter, et ne jamais afficher un refus fondé sur une query.
 
 #### Labels UI (copy)
 
@@ -936,6 +942,9 @@ L'UI propose une section dépliable "Tester un scope" sous les body filters. Ell
 | Bouton | "Tester" |
 | Résultat autorisé | "Accès autorisé" (vert) |
 | Résultat refusé | "Accès refusé" (rouge) |
+| Note query, affichée dès que le chemin de test contient un `?` | « La query n'est pas contrainte par les scopes : tous les paramètres passent. » |
+
+La note sur la query est **permanente tant que `queryFilters` n'est pas livré** (§18.4). Elle existe parce que l'ancien testeur affirmait le contraire et refusait des requêtes que la production acceptait.
 
 ### 12.6 Sécurité de l'UI
 
@@ -1228,8 +1237,9 @@ La section se compose de trois blocs, dans cet ordre :
 | Libellé du `<summary>` | « Les erreurs de FGP » |
 | Sous-titre du groupe 1 | « La clé ou le blob » |
 | Sous-titre du groupe 2 | « Le périmètre du blob » |
-| Sous-titre du groupe 3 | « FGP n'a pas pu joindre l'API cible » |
-| Sous-titre du groupe 4 | « Anomalies » |
+| Sous-titre du groupe 3 | « La cible du blob » |
+| Sous-titre du groupe 4 | « FGP n'a pas pu obtenir de credentials ou joindre l'API cible » |
+| Sous-titre du groupe 5 | « Anomalies » |
 
 **Groupe 1, « La clé ou le blob »** :
 
@@ -1238,6 +1248,7 @@ La section se compose de trois blocs, dans cet ordre :
 | `missing_key` (401) | « L'en-tête `X-FGP-Key` est absent de la requête. Sans la clé client, le blob ne peut pas être déchiffré. » |
 | `invalid_credentials` (401) | « Le déchiffrement a échoué. La clé ne correspond pas à ce blob, le blob a été tronqué ou modifié, ou il a été généré sur une autre instance FGP. » |
 | `blob_too_large` (414) | « Le blob dépasse 4 Ko. Réduisez le nombre de scopes, de body filters ou de headers d'authentification. Le mode en-tête ne contourne pas cette limite : elle porte sur la taille du blob, pas sur son transport. » |
+| `unsupported_regex` (400) | « Une expression régulière de ce blob n'est plus autorisée : les groupes quantifiés, les backréférences et les lookarounds sont refusés. Le blob doit être régénéré avec un motif plus simple. » |
 
 **Groupe 2, « Le périmètre du blob »** :
 
@@ -1246,8 +1257,15 @@ La section se compose de trois blocs, dans cet ordre :
 | `scope_denied` (403) | « La méthode ou le chemin demandé ne correspond à aucun scope du blob. Si des body filters sont configurés, le contenu de la requête peut aussi être en cause. La section « Tester un scope » rejoue le cas sans consommer d'appel. » |
 | `token_expired` (410) | « Le TTL du blob est dépassé. Une URL expirée ne se prolonge pas, il faut en générer une nouvelle. » |
 | `invalid_body` (400) | « Des body filters sont configurés mais le corps de la requête n'est pas du JSON valide. Vérifiez aussi que l'en-tête `Content-Type` vaut bien `application/json`, sinon la requête est refusée en `scope_denied`. » |
+| `payload_too_large` (413) | « Le corps de la requête dépasse la taille inspectable, 512 Ko, quand un body filter ou la capture des logs détaillés est actif. Sans ces deux fonctions, le corps est transmis en flux et n'est pas plafonné. » |
 
-**Groupe 3, « FGP n'a pas pu obtenir de credentials ou joindre l'API cible »** :
+**Groupe 3, « La cible du blob »** :
+
+| Code et status | Texte de remédiation |
+|----------------|----------------------|
+| `target_forbidden` (403) | « La cible de ce blob n'est pas une adresse publique. FGP refuse de joindre les réseaux privés, la boucle locale et les adresses de métadonnées. Vérifiez l'URL cible du blob. » |
+
+**Groupe 4, « FGP n'a pas pu obtenir de credentials ou joindre l'API cible »** :
 
 | Code et status | Texte de remédiation |
 |----------------|----------------------|
@@ -1256,11 +1274,22 @@ La section se compose de trois blocs, dans cet ordre :
 | `auth_exchange_failed` (502) | « Mode Scalingo API : impossible de s'authentifier auprès de Scalingo. Le token de compte du blob est invalide ou révoqué, ou l'API d'authentification Scalingo est indisponible. » |
 | `auth_addon_failed` (502) | « Mode Scalingo Database API : impossible d'obtenir un token de base de données. Le token de compte est invalide, ou il n'a pas accès à la base configurée dans ce blob. » |
 
-**Groupe 4, « Anomalies »** : trois codes rares, regroupés en une seule entrée pour ne pas allonger la liste.
+**Groupe 5, « Anomalies »** : trois codes rares, regroupés en une seule entrée pour ne pas allonger la liste.
 
 | Élément | Texte |
 |---------|-------|
 | Entrée unique | « `invalid_request` (400) quand l'URL ne contient pas de chemin après le blob, `invalid_auth_mode` (400) quand le mode d'authentification du blob n'est pas reconnu par cette instance, et `internal_error` (500) qui signale un bug de FGP et mérite un rapport. » |
+
+#### Bloc 2 bis : la query n'est pas contrainte (visible)
+
+À placer sous la liste des codes, hors du `<details>`, parce que ce n'est pas une erreur mais une absence de refus, et que personne ne la cherchera dans une liste de codes.
+
+| Élément | Texte |
+|---------|-------|
+| Titre du bloc | « Les paramètres de query ne sont pas contrôlés » |
+| Texte | « Les scopes contraignent la méthode et le chemin, pas les paramètres de query. Un blob autorisé sur `/v1/items` accepte `/v1/items?action=delete`. Si votre API cible expose des actions par la query, scopez le chemin le plus étroitement possible. » |
+
+Ce bloc disparaît le jour où `queryFilters` est livré (§18.4). Tant qu'il est là, il dit la vérité opérationnelle du produit à l'endroit où quelqu'un construit un blob en croyant le restreindre.
 
 #### Bloc 3 : « Tout le reste vient de votre API » (visible)
 
@@ -1323,6 +1352,18 @@ La distinction n'est pas cosmétique : « notez cette clé maintenant » adress�
 
 Traitement visuel : même registre que l'avertissement de mutualisation, pas plus fort. C'est une consigne, pas une alerte de sécurité.
 
+### 12.13 Blocs d'alerte : pas de titre
+
+**Règle confirmée** : un bloc d'alerte n'a pas de titre. Le niveau est porté par l'icône et la couleur, le texte dit ce qui se passe.
+
+Le titre « Attention » en gras a donc disparu de l'encadré de la clé client, et ne doit pas revenir. Il ne portait aucune information : c'est une étiquette de catégorie, pas un contenu, exactement le même défaut que « cliquez ici » sur un lien (§12.11, règle 1). Il coûtait une troisième ligne, ce qui faisait sortir le bloc de son budget de hauteur.
+
+Le corollaire du designer est la partie la plus utile de la règle, et elle vaut au-delà de ce bloc : **si un bloc d'alerte a besoin d'un titre pour être compris, son texte relève de la documentation.** Un titre qui rend un avertissement lisible est le symptôme d'un avertissement trop long.
+
+**Une condition d'accessibilité s'y ajoute, et elle n'est pas optionnelle.** L'icône est décorative donc `aria-hidden`, et la couleur n'est pas un canal d'information pour qui ne la perçoit pas. Ni l'une ni l'autre n'atteint un lecteur d'écran. **La gravité doit donc rester déductible du texte seul.** Elle l'est pour l'encadré de la clé client : « Réutiliser une clé lie les blobs : sa fuite rend déchiffrables tous ceux générés avec elle » porte sa propre alarme, sans avoir besoin qu'on la qualifie.
+
+Un texte d'alerte qui ne se comprendrait comme une alerte qu'en voyant sa couleur est mal écrit, et retirer son titre a le mérite de le révéler.
+
 ---
 
 ## 13. Limites et non-goals (v4)
@@ -1338,6 +1379,11 @@ Traitement visuel : même registre que l'avertissement de mutualisation, pas plu
 - **Pas de rotation de clé client** : changer la clé d'un blob impose de le regénérer. FGP ne connaît pas la clé et ne peut pas rechiffrer un blob existant.
 - **Pas de valeurs dynamiques dans les headers d'auth** : les valeurs sont statiques, figées au moment de la génération. Pas de templating, pas de variables d'environnement, pas d'interpolation depuis la requête entrante.
 - **Pas de `/llms-full.txt` ni de `/robots.txt`** : un seul document `/llms.txt` (cf. §16).
+- **Aucune contrainte sur les paramètres de query**, tant que `queryFilters` n'est pas livré. Non-garantie **datée**, pas oubli : la décision est prise, son implémentation est différée (§18.4).
+- **Pas de limitation de débit dans l'application** : l'axe relève de l'opérateur (§18.6 et les guides de déploiement).
+- **Pas de protection contre le rebinding DNS** : la politique de sortie est un ralentisseur, pas une preuve (§18.2).
+- **FGP n'est pas un WAF** : hors des filtres déclarés dans le scope, le contenu de la requête n'est pas examiné.
+- **FGP ne protège pas le créateur d'un blob contre la cible publique qu'il a lui-même choisie.** Le blob est une délégation : la politique de sortie protège l'hôte FGP et son réseau, pas l'utilisateur contre lui-même.
 - **Aucun secret d'auth n'est récupérable** : ni `token`, ni les valeurs de headers ne sont réaffichables après génération. Les endpoints de décodage renvoient des valeurs redactées (cf. §11.1.4).
 
 ---
@@ -1888,3 +1934,98 @@ L'UI ne contient aucun script ni style inline : la CSP passe sans `unsafe-inline
 Swagger UI charge ses assets depuis un CDN externe et pose un script inline non nonçable. La CSP de §17.2 le casserait. Cette route reçoit donc une **CSP dédiée**, plus permissive mais toujours explicite : `script-src` et `style-src` limités à `'self'`, `'unsafe-inline'` et l'origine du CDN, `img-src` et `font-src` étendus à cette même origine. Tout le reste (dont `frame-ancestors 'none'` et `default-src 'none'`) est conservé.
 
 `/api/docs` n'est jamais servie sans CSP. La cible à terme reste l'auto-hébergement des assets Swagger dans `/static/`, ce qui permettrait de lui appliquer la CSP commune et de supprimer la dépendance à un CDN tiers. C'est un chantier séparé, non bloquant pour ce lot.
+
+---
+
+## 18. Politique de sortie et limites de ressources
+
+Cette section résume les contrats établis par l'ADR-0009 (sortie du proxy) et l'ADR-0010 (limites de ressources). Les ADR font foi sur le raisonnement, cette section sur le comportement observable.
+
+### 18.1 Les quatre garanties
+
+Le contrat vaut pour **tout appel réseau sortant émis par FGP**, sans exception : forward du proxy, endpoints d'aide de l'UI, obtention de credentials upstream. Tous passent par un point de sortie unique.
+
+| Garantie | Énoncé |
+|----------|--------|
+| **G1, destination** | Toute requête sortante vise un schéma `http` ou `https` et une adresse **publique**. FGP ne se laisse pas utiliser comme relais vers le réseau privé de son hébergeur. |
+| **G2, chemin** | Le chemin autorisé par les scopes est le chemin émis vers l'upstream, octet pour octet. Aucune forme décodée ou normalisée n'échappe au contrôle. Indépendant du mode de livraison du blob. |
+| **G3, en-têtes** | L'authentification que voit l'upstream vient du blob, jamais de l'appelant. Aucun en-tête de transport, d'authentification ou de provenance fourni par l'appelant n'atteint l'upstream (§11.2). |
+| **G4, query** | Les paramètres de query sont soit contraints par le scope, soit transmis librement, et l'outillage dit lequel des deux s'applique. Il n'existe aucun cas où l'interface affirme une contrainte que le proxy n'applique pas. |
+
+Les non-garanties sont énumérées en §13, au même titre que les garanties. Une politique de sécurité qui ne dit pas ce qu'elle ne couvre pas invite à lui prêter des propriétés qu'elle n'a pas.
+
+### 18.2 Hôte : refus par nature de l'adresse
+
+FGP est agnostique par conception, donc **pas d'allowlist de cibles** : elle transformerait un proxy générique en passerelle configurée. La décision est prise à l'envers, **tout hôte public est autorisé, toute destination non publique est refusée**, ce qui ne restreint aucun usage légitime.
+
+Trois temps :
+
+1. **Forme**, purement syntaxique. Le `target` doit être une URL absolue en `http` ou `https`, sans userinfo, sans query, sans fragment, avec un chemin de base ne contenant ni `%2f`, ni `..`, ni `\`. Vérifié à la génération (400 `invalid_target`) et au déchiffrement (blob malformé, donc 401 `invalid_credentials`).
+2. **Adresse**, après résolution. Les plages loopback, privées, link-local, CGNAT, unique-local, multicast et réservées sont refusées, en IPv4 comme en IPv6 et dans toutes leurs notations, ainsi que les noms en `.internal`, `.local`, `.localhost`, `.home.arpa` et les noms sans point. Pour un nom, **toutes** les adresses résolues doivent être publiques. Refus en 403 `target_forbidden`.
+3. **Redirections non suivies** (`redirect: "manual"`). Sans cela la classification ne vaut rien : un hôte public autorisé redirigerait vers l'adresse de métadonnées, et les en-têtes d'auth y seraient rejoués.
+
+Un échec de résolution DNS n'est **pas** un refus de politique : la requête continue et échoue naturellement en 502 `upstream_unreachable`. Un nom qui ne résout pas ne joint rien, et transformer chaque incident DNS en refus opaque n'apporterait rien.
+
+Le champ `apiUrl` du mode `scalingo-addon`, ainsi que le `target` de `/api/list-apps` et `/api/list-addons`, reçoivent une contrainte plus forte : leur hôte doit se terminer par `.scalingo.com`. Ce n'est pas une entorse à l'agnosticisme, qui est une propriété de `target` et non des modes d'auth propriétaires : ce mode présente un bearer de compte à l'hôte désigné, un `apiUrl` libre serait un canal d'exfiltration de credential.
+
+**Le rebinding DNS reste ouvert.** Entre la résolution de contrôle et le `fetch`, le nom est résolu une seconde fois par le runtime et rien ne garantit la même réponse. La défense réelle est le filtrage d'egress au niveau réseau, au déploiement. La politique de code est un ralentisseur solide, elle n'est pas une preuve.
+
+### 18.3 Chemin : contrôle sur toutes les formes, émission de la forme brute
+
+Le contrôle porte sur **deux formes** du chemin, l'émission sur une seule.
+
+```
+formeBrute      = le chemin tel que reçu, à l'octet près
+formeCanonique  = décodage percent répété jusqu'au point fixe (3 tours max),
+                  puis `\` remplacé par `/`, slashes répétés écrasés,
+                  puis résolution des segments `.` et `..`
+
+accès autorisé  <=>  autorisé(formeBrute) ET autorisé(formeCanonique)
+émission        =    formeBrute
+```
+
+La règle est **fail-closed et monotone** : ajouter une forme au jeu de vérification ne peut que réduire l'ensemble autorisé, jamais l'élargir. L'ADR-0006 est intact, ce qui part sur le fil est inchangé.
+
+Les deux voies naturelles ont été écartées et méritent d'être connues, parce qu'elles reviendront : **refuser `%2f`** casse les APIs qui encodent un `/` dans un identifiant (GitLab en tête), et **décoder avant de forwarder** casse les mêmes APIs plus profondément, silencieusement, en émettant une route différente de celle demandée.
+
+Conséquences observables :
+
+- L'attaque tombe : brut `/v1/public/..%2f..%2fadmin`, canonique `/admin`, le scope `GET:/v1/public/*` ne couvre pas la seconde forme, donc 403 `scope_denied`.
+- Le cas légitime passe : brut `/api/v4/projects/groupe%2Fprojet`, canonique `/api/v4/projects/groupe/projet`, le scope `GET:/api/v4/projects/*` couvre les deux.
+- **Certains scopes en correspondance exacte deviennent plus stricts.** Un scope `GET:/projects/groupe%2Fprojet` ne suffit plus seul, la forme décodée doit être couverte aussi. C'est le coût ergonomique assumé de la décision.
+- Un chemin contenant un octet NUL ou un caractère de contrôle après décodage est rejeté en 400 `invalid_request`.
+- Les deux modes de livraison du blob produisent désormais la **même** chaîne pour la même requête. Auparavant `/v1//public//x` était évalué différemment en mode URL et en mode header, soit deux surfaces d'autorisation pour un seul blob.
+
+### 18.4 Query : non contrainte, et c'est écrit
+
+**État actuel, sans détour : un blob scopé sur un chemin autorise toutes les querys de ce chemin.** Un scope `GET:/v1/items` laisse passer `/v1/items?action=delete&scope=all`. Les paramètres destructeurs (`?force=true`, `?recursive=true`, `?permanent=true`) ne sont contraints par rien.
+
+Ce n'est pas un non-goal, c'est une **dette datée**. La décision est prise : la query entre dans le modèle de scopes, sous la forme d'un axe `queryFilters` sur `ScopeEntry`, calqué sur les body filters, opt-in, avec déni par défaut à l'intérieur du scope, et un bump du blob en v5. Tout cela est arbitré dans l'ADR-0009 §4 et n'aura pas à être rejoué.
+
+**Son implémentation est différée en feature séparée**, pour une raison de périmètre et non de doute : le lot de sécurité corrigeait des vulnérabilités en production et devait partir vite, un nouveau format de blob allonge la review et élargit la surface de régression. Mélanger les deux aurait fait payer au correctif urgent le prix de la feature.
+
+Entre les deux livraisons, trois choses seulement sont acquises :
+
+1. **Un `?` dans un pattern de scope est refusé à la génération** (400 `invalid_scope`). Il produisait un scope mort dont l'auteur croyait qu'il contraignait quelque chose. Au déchiffrement en revanche, un blob qui en porte un reste valide, le pattern est simplement sans effet : refuser casserait des blobs vivants sur leurs autres scopes pour un gain de sécurité nul.
+2. **La non-contrainte est dite partout** : ici, dans le panneau Doc et dans `/llms.txt`.
+3. **Le testeur de scopes ne ment plus** (§12.5).
+
+### 18.5 Limites de ressources
+
+Toutes calibrées sur un critère unique : **aucune primitive optionnelle ne doit coûter plus cher que la dérivation de clé obligatoire déjà présente sur le chemin**, soit environ 11,6 ms. Une fonctionnalité optionnelle qui dépasse ce plancher devient le coût dominant de l'instance. Le détail chiffré est dans `docs/limits.md`, les mesures dans l'ADR-0010.
+
+Ce qui est observable côté client :
+
+- **413 `payload_too_large`** sur `/api/*` au-delà du plafond de la route, et sur le proxy au-delà de 512 Ko de corps quand un body filter ou la capture detailed est actif.
+- **Le streaming du corps proxy est préservé** quand aucun body filter ni capture detailed n'est actif : les gros uploads à travers le proxy continuent de passer sans être mis en mémoire. C'est une propriété du proxy transparent qu'il ne fallait pas perdre en posant la limite au mauvais endroit.
+- **400 `unsupported_regex`** quand une regex du blob sort du dialecte autorisé.
+
+### 18.6 Limitation de débit : hors de l'application, et pourquoi
+
+Toutes les limites ci-dessus bornent le **coût d'une requête**. Aucune ne borne le **nombre de requêtes**. C'est un choix.
+
+Un limiteur en mémoire du processus est **quasi inopérant sur Deno Deploy** : l'état est par isolate, les isolates sont éphémères, et les requêtes se répartissent entre eux. Il fonctionnerait en auto-hébergement, où le processus est unique et durable. Livrer un limiteur applicatif efficace sur une cible de déploiement sur deux donnerait une **fausse couverture**, ce qui est pire que pas de couverture : l'opérateur croirait le problème réglé.
+
+La limitation de débit est donc documentée **côté opérateur**, par cible de déploiement, dans `docs/deno-deploy.md` et `docs/scalingo-deploy.md`.
+
+L'ordre de grandeur qui justifie qu'on ne l'ignore pas : avant les correctifs de l'ADR-0010, **1 900 requêtes suffisaient à épuiser les 20 heures de CPU mensuelles** du plan gratuit de la plateforme. Les correctifs suppriment le coût unitaire aberrant, ils ne suppriment pas la nécessité d'une borne sur le débit.

--- a/src/routes/llms.ts
+++ b/src/routes/llms.ts
@@ -22,7 +22,10 @@ stripped because the proxy is stateless. Errors produced by FGP itself use the
 JSON shape \`{"error": "...", "message": "..."}\`. Every response carries the
 \`X-FGP-Source\` header: \`upstream\` when the payload comes from the target API,
 \`proxy\` when FGP produced it. Use that header to decide who to blame and whether
-retrying makes sense.
+retrying makes sense. Redirects are not followed: a 3xx from the target reaches
+the caller unchanged, \`Location\` header included, and following it is the
+caller's decision. A blob is bound to one target host, so an automatic redirect
+would silently send the upstream credentials to a host nobody scoped.
 
 Calling a proxied endpoint. Two equivalent transports:
 
@@ -44,6 +47,12 @@ POST:/v1/apps/my-app/scale  exact path, exact method
 *:*                         everything, use with a short TTL only
 \`\`\`
 
+Scopes constrain the method and the path only. **Query string parameters are not
+inspected**: a scope on \`POST:/v1/apps/my-app/scale\` also allows
+\`POST /v1/apps/my-app/scale?force=true\`. Grant a path only when every query
+variant of that path is acceptable. Declaring a scope that carries a \`?\` is
+rejected rather than silently ignored.
+
 Authentication modes, set in the \`auth\` field of the blob:
 
 - \`bearer\`: sends \`Authorization: Bearer {token}\`.
@@ -60,7 +69,12 @@ Authentication modes, set in the \`auth\` field of the blob:
   database per blob.
 
 Auth headers are applied after the caller's own headers, so a consumer can never
-override or neutralize the authentication carried by the blob.
+override or neutralize the authentication carried by the blob. The caller's own
+\`Authorization\`, \`Cookie\` and \`Proxy-Authorization\` headers are stripped before
+forwarding: the product promise is that the consumer does not hold the target's
+credential, and relaying its own would sidestep the scope model. An API needing a
+second credential is served by the \`headers\` mode, which puts it in the blob.
+Hop-by-hop and forwarding headers are stripped too; everything else passes.
 
 Body filters restrict the JSON body of POST, PUT and PATCH requests. A scope
 entry carries \`bodyFilters\`, each with an \`objectPath\` (dot-path, 6 segments
@@ -79,10 +93,13 @@ Error codes produced by FGP (\`X-FGP-Source: proxy\`):
 - 400 \`invalid_request\`: the proxy path has fewer than 2 segments.
 - 400 \`invalid_auth_mode\`: the blob declares an auth mode this instance ignores.
 - 400 \`invalid_body\`: body filters are required but the body is not valid JSON.
+- 400 \`unsupported_regex\`: a scope regex falls outside the accepted dialect.
 - 401 \`missing_key\`: the \`X-FGP-Key\` header is absent.
 - 401 \`invalid_credentials\`: wrong client key, or corrupted or malformed blob.
 - 403 \`scope_denied\`: no scope matches the method, path or body.
+- 403 \`target_forbidden\`: the target host is not a public address.
 - 410 \`token_expired\`: the blob TTL has elapsed.
+- 413 \`payload_too_large\`: the request body exceeds the inspection limit.
 - 414 \`blob_too_large\`: the blob exceeds 4096 characters.
 - 500 \`internal_error\`: unexpected proxy failure.
 - 502 \`upstream_unreachable\`: the target API could not be reached at all.

--- a/src/ui/client/test-scope.ts
+++ b/src/ui/client/test-scope.ts
@@ -79,7 +79,15 @@ export function setupTestScope(
   const verdictSpan = assertElement("test-scope-verdict", HTMLElement);
   const jsonContainer = assertElement("test-scope-json", HTMLElement);
   const scopesTextarea = assertElement("scopes", HTMLTextAreaElement);
+  const queryNote = assertElement("test-query-note", HTMLElement);
   const badge = document.getElementById("test-scope-badge");
+
+  // La note se retire d'elle-meme le jour ou un scope contraint la query : elle est
+  // pilotee par le verdict, pas par une constante a retrouver (§18.4).
+  function updateQueryNote(queryConstrained: boolean): void {
+    const [, rawSearch] = splitPathAndQuery(pathInput.value);
+    queryNote.hidden = rawSearch.length === 0 || queryConstrained;
+  }
 
   function updateBadge(): void {
     if (!badge) return;
@@ -105,6 +113,7 @@ export function setupTestScope(
 
     jsonContainer.textContent = "";
     jsonContainer.classList.add("hidden");
+    updateQueryNote(false);
 
     if (rawScopes.length === 0 || path.length === 0) {
       clearElement(resultsContainer);
@@ -118,26 +127,24 @@ export function setupTestScope(
 
     clearElement(resultsContainer);
     let anyMatch = false;
+    let queryConstrained = false;
 
     // Une seule lecture des scopes, la meme que celle du proxy : c'est ce qui empeche
     // l'interface d'affirmer un refus la ou la production repond 200 (ADR-0009 §4).
     for (let i = 0; i < scopes.length; i++) {
       const scope = scopes[i] as Scope;
-      const matched = checkRequestAccess([scope], method.toUpperCase(), path, body).allowed;
-      if (matched) anyMatch = true;
-      resultsContainer.appendChild(createResultRow(matched, scopeLabel(scopes[i])));
+      const verdict = checkRequestAccess([scope], method.toUpperCase(), path, body);
+      if (verdict.allowed) anyMatch = true;
+      if (verdict.queryConstrained) queryConstrained = true;
+      resultsContainer.appendChild(createResultRow(verdict.allowed, scopeLabel(scopes[i])));
     }
 
-    const [, rawSearch] = splitPathAndQuery(path);
+    updateQueryNote(queryConstrained);
+
     if (!anyMatch) {
       btnTest.disabled = true;
       verdictSpan.textContent = "Proxy : acc\u00e8s refus\u00e9";
       verdictSpan.className = "text-sm font-medium text-red-600 dark:text-red-400";
-    } else if (rawSearch.length > 0) {
-      btnTest.disabled = false;
-      verdictSpan.textContent =
-        "Acc\u00e8s autoris\u00e9. La query n'est pas contrainte par les scopes, elle est transmise telle quelle.";
-      verdictSpan.className = "text-sm font-medium text-amber-700 dark:text-amber-300";
     } else {
       btnTest.disabled = false;
       verdictSpan.textContent = "";

--- a/src/ui/config/form-scopes.tsx
+++ b/src/ui/config/form-scopes.tsx
@@ -1,4 +1,12 @@
-import { CONTROL_H_SM, HINT_CLASS, LABEL_CLASS, SUB_LABEL_CLASS } from "./constants.ts";
+import {
+  ALERT_INFO_CLASS,
+  CONTROL_H_SM,
+  HINT_CLASS,
+  LABEL_CLASS,
+  SUB_LABEL_CLASS,
+} from "./constants.ts";
+import { AlertInfoIcon } from "./icons.tsx";
+
 export function ScopesSection() {
   return (
     <section>
@@ -100,6 +108,13 @@ export function TestScopeSection() {
             />
           </div>
         </div>
+
+        <p id="test-query-note" hidden aria-live="polite" class={ALERT_INFO_CLASS}>
+          <AlertInfoIcon />
+          <span>
+            La query n'est pas contrainte par les scopes : tous les param&egrave;tres passent.
+          </span>
+        </p>
 
         <div id="test-body-section" class="hidden">
           <label

--- a/src/ui/config/sidebar-doc.tsx
+++ b/src/ui/config/sidebar-doc.tsx
@@ -152,6 +152,17 @@ export function DocPanel() {
                   limite : elle porte sur la taille du blob, pas sur son transport.
                 </dd>
               </div>
+              <div>
+                <dt class="font-medium text-gray-800 dark:text-gray-200">
+                  <code class="font-mono text-xs">unsupported_regex</code> (400)
+                </dt>
+                <dd>
+                  Une expression r&eacute;guli&egrave;re de ce blob n'est plus autoris&eacute;e :
+                  les groupes quantifi&eacute;s, les backr&eacute;f&eacute;rences et les lookarounds
+                  sont refus&eacute;s. Le blob doit &ecirc;tre r&eacute;g&eacute;n&eacute;r&eacute;
+                  avec un motif plus simple.
+                </dd>
+              </div>
             </dl>
           </div>
 
@@ -190,6 +201,32 @@ export function DocPanel() {
                   <code class="font-mono text-xs">Content-Type</code> vaut bien{" "}
                   <code class="font-mono text-xs">application/json</code>, sinon la requ&ecirc;te
                   est refus&eacute;e en <code class="font-mono text-xs">scope_denied</code>.
+                </dd>
+              </div>
+              <div>
+                <dt class="font-medium text-gray-800 dark:text-gray-200">
+                  <code class="font-mono text-xs">payload_too_large</code> (413)
+                </dt>
+                <dd>
+                  Le corps de la requ&ecirc;te d&eacute;passe la taille inspectable, 512 Ko, quand
+                  un body filter ou la capture des logs d&eacute;taill&eacute;s est actif. Sans ces
+                  deux fonctions, le corps est transmis en flux et n'est pas plafonn&eacute;.
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="mt-3">
+            <p class="font-medium text-gray-700 dark:text-gray-300">La cible du blob</p>
+            <dl class="mt-1 space-y-2">
+              <div>
+                <dt class="font-medium text-gray-800 dark:text-gray-200">
+                  <code class="font-mono text-xs">target_forbidden</code> (403)
+                </dt>
+                <dd>
+                  La cible de ce blob n'est pas une adresse publique. FGP refuse de joindre les
+                  r&eacute;seaux priv&eacute;s, la boucle locale et les adresses de
+                  m&eacute;tadonn&eacute;es. V&eacute;rifiez l'URL cible du blob.
                 </dd>
               </div>
             </dl>
@@ -251,6 +288,17 @@ export function DocPanel() {
             </p>
           </div>
         </details>
+
+        <p class="mt-3 font-medium text-gray-800 dark:text-gray-200">
+          Les param&egrave;tres de query ne sont pas contr&ocirc;l&eacute;s
+        </p>
+        <p class="mt-1">
+          Les scopes contraignent la m&eacute;thode et le chemin, pas les param&egrave;tres de
+          query. Un blob autoris&eacute; sur <code class="font-mono text-xs">/v1/items</code>{" "}
+          accepte{" "}
+          <code class="font-mono text-xs">/v1/items?action=delete</code>. Si votre API cible expose
+          des actions par la query, scopez le chemin le plus &eacute;troitement possible.
+        </p>
 
         <p class="mt-3 font-medium text-gray-800 dark:text-gray-200">
           Tout le reste vient de votre API

--- a/tests/testu/llms-txt.test.ts
+++ b/tests/testu/llms-txt.test.ts
@@ -129,6 +129,38 @@ Deno.test("AC-40.8: le contenu de fond couvre les concepts indispensables", () =
   }
 });
 
+Deno.test("AC-40.18: les codes d'erreur du proxy sont tous documentes", () => {
+  for (
+    const code of [
+      "invalid_request",
+      "invalid_auth_mode",
+      "invalid_body",
+      "unsupported_regex",
+      "missing_key",
+      "invalid_credentials",
+      "scope_denied",
+      "target_forbidden",
+      "token_expired",
+      "payload_too_large",
+      "blob_too_large",
+      "internal_error",
+      "upstream_unreachable",
+      "auth_exchange_failed",
+      "auth_addon_failed",
+    ]
+  ) {
+    assertStringIncludes(doc, code);
+  }
+});
+
+Deno.test("AC-40.19: les trois non-garanties de la politique de sortie sont dites", () => {
+  // Un agent qui construit un blob depuis ce document doit lire ces trois faits ici :
+  // les decouvrir en production coute une fuite de credentials ou un scope contourne.
+  assertStringIncludes(doc, "Query string parameters are not\ninspected");
+  assertStringIncludes(doc, "Redirects are not followed");
+  assertStringIncludes(doc, "are stripped before\nforwarding");
+});
+
 Deno.test("AC-40.8: les six modes d'authentification sont nommes", () => {
   for (
     const mode of ["bearer", "basic", "scalingo-exchange", "header:", "headers", "scalingo-addon"]

--- a/tests/testu/ui/config-page.test.ts
+++ b/tests/testu/ui/config-page.test.ts
@@ -1,8 +1,18 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 
 import { ConfigPage } from "../../../src/ui/config-page.tsx";
+import { ALERT_INFO_CLASS } from "../../../src/ui/config/constants.ts";
+import { renderLlmsTxt } from "../../../src/routes/llms.ts";
 
 const html = String(ConfigPage({ commitHash: "test" }));
+
+/** Rendu debarrasse du balisage et des entites, pour comparer la copy au mot pres. */
+const copy = html
+  .replace(/<[^>]+>/g, " ")
+  .replace(/&#39;/g, "'")
+  .replace(/&quot;/g, '"')
+  .replace(/&amp;/g, "&")
+  .replace(/\s+/g, " ");
 
 /** Attributs de la balise portant l'identifiant donne. */
 function tagAttributes(id: string): string {
@@ -11,6 +21,25 @@ function tagAttributes(id: string): string {
   const open = html.lastIndexOf("<", index);
   const close = html.indexOf(">", index);
   return html.slice(open, close + 1);
+}
+
+/** Fragment de rendu allant de la balise ouvrante de l'element a sa fermeture. */
+function elementHtml(id: string, closingTag: string): string {
+  const index = html.indexOf(`id="${id}"`);
+  assertEquals(index >= 0, true, `element introuvable dans le rendu : #${id}`);
+  const open = html.lastIndexOf("<", index);
+  const end = html.indexOf(closingTag, index);
+  assertEquals(end >= 0, true, `fermeture ${closingTag} introuvable pour #${id}`);
+  return html.slice(open, end + closingTag.length);
+}
+
+/** Contenu du <details> qui replie la liste des codes d'erreur FGP. */
+function errorDetailsHtml(): string {
+  const summary = html.indexOf("Les erreurs de FGP");
+  assertEquals(summary >= 0, true, "summary « Les erreurs de FGP » introuvable");
+  const end = html.indexOf("</details>", summary);
+  assertEquals(end >= 0, true, "fermeture du <details> des codes d'erreur introuvable");
+  return html.slice(summary, end);
 }
 
 Deno.test("AC-39.4: #byok-key n'a ni required, ni minlength, ni pattern, ni maxlength", () => {
@@ -72,4 +101,132 @@ Deno.test("AC-39.17: aucune balise style, les feuilles viennent de /static", () 
 Deno.test("AC-40.13: la page declare la decouverte /llms.txt dans son head", () => {
   assertStringIncludes(html, 'rel="describedby"');
   assertStringIncludes(html, 'href="/llms.txt"');
+});
+
+Deno.test("§12.10: les trois nouveaux codes d'erreur sont documentes avec leur status", () => {
+  for (
+    const [code, status] of [
+      ["unsupported_regex", "400"],
+      ["payload_too_large", "413"],
+      ["target_forbidden", "403"],
+    ]
+  ) {
+    assertStringIncludes(
+      html,
+      `<code class="font-mono text-xs">${code}</code> (${status})`,
+      `${code} absent du panneau Doc, ou sans son status`,
+    );
+  }
+});
+
+Deno.test("§12.10: les cinq groupes de codes portent les sous-titres de la spec, dans l'ordre", () => {
+  const subtitles = [
+    "La clé ou le blob",
+    "Le périmètre du blob",
+    "La cible du blob",
+    "FGP n'a pas pu obtenir de credentials ou joindre l'API cible",
+    "Anomalies",
+  ];
+
+  let previous = -1;
+  for (const subtitle of subtitles) {
+    const index = copy.indexOf(subtitle, previous + 1);
+    assertEquals(index > previous, true, `sous-titre de groupe absent ou mal place : ${subtitle}`);
+    previous = index;
+  }
+});
+
+Deno.test("§12.10: la remediation des nouveaux codes reprend la copy du PO au mot pres", () => {
+  const texts = [
+    "Une expression régulière de ce blob n'est plus autorisée : les groupes quantifiés, " +
+    "les backréférences et les lookarounds sont refusés. Le blob doit être régénéré avec " +
+    "un motif plus simple.",
+    "Le corps de la requête dépasse la taille inspectable, 512 Ko, quand un body filter ou " +
+    "la capture des logs détaillés est actif. Sans ces deux fonctions, le corps est transmis " +
+    "en flux et n'est pas plafonné.",
+    "La cible de ce blob n'est pas une adresse publique. FGP refuse de joindre les réseaux " +
+    "privés, la boucle locale et les adresses de métadonnées. Vérifiez l'URL cible du blob.",
+  ];
+
+  for (const text of texts) {
+    assertStringIncludes(copy, text);
+  }
+});
+
+Deno.test("§12.10: le bloc sur la query est visible, hors du <details> des codes", () => {
+  const title = "Les paramètres de query ne sont pas contrôlés";
+
+  // Ce n'est pas une erreur mais une absence de refus : la replier avec les codes la rendrait
+  // introuvable pour qui construit un blob en croyant le restreindre.
+  assertStringIncludes(copy, title);
+  assertEquals(
+    errorDetailsHtml().includes(title),
+    false,
+    "le bloc query a ete replie dans le <details> des codes d'erreur",
+  );
+
+  assertStringIncludes(
+    copy,
+    "Les scopes contraignent la méthode et le chemin, pas les paramètres de query.",
+  );
+  assertStringIncludes(
+    copy,
+    "Si votre API cible expose des actions par la query, scopez le chemin le plus étroitement " +
+      "possible.",
+  );
+  assertStringIncludes(html, '<code class="font-mono text-xs">/v1/items?action=delete</code>');
+});
+
+Deno.test("§12.10: le panneau Doc couvre tous les codes proxy annonces par /llms.txt", () => {
+  // Deux surfaces documentent les memes erreurs a deux publics. Une divergence signifie qu'une
+  // des deux ment, et rien dans le code ne l'aurait signalee.
+  const llms = renderLlmsTxt("https://fgp.example.com");
+  const heading = llms.indexOf("Error codes produced by FGP");
+  assertEquals(heading >= 0, true, "liste des codes introuvable dans /llms.txt");
+
+  // Le seul bloc qui suit le titre : une future liste de codes pour /api/* ne doit pas
+  // etre confondue avec celle de la route proxy.
+  const block = llms.slice(heading).split("\n\n")[1] ?? "";
+  const codes = [...block.matchAll(/^- (\d{3}) `([a-z_]+)`:/gm)];
+
+  assertEquals(codes.length, 15, "le nombre de codes listes par /llms.txt a change");
+
+  for (const [, status, code] of codes) {
+    assertStringIncludes(
+      html,
+      `<code class="font-mono text-xs">${code}</code> (${status})`,
+      `${code} (${status}) est documente par /llms.txt mais absent du panneau Doc`,
+    );
+  }
+});
+
+Deno.test("§12.5: la note query du testeur porte la copy de la spec et part masquee", () => {
+  const tag = tagAttributes("test-query-note");
+
+  assertStringIncludes(tag, "hidden");
+  // La note remplace un message que le verdict annoncait : sans region live, elle
+  // apparaitrait en silence pour un lecteur d'ecran.
+  assertStringIncludes(tag, 'aria-live="polite"');
+  assertStringIncludes(
+    tag,
+    `class="${ALERT_INFO_CLASS}"`,
+    "la note doit reutiliser le gabarit d'alerte partage, pas une classe ad hoc",
+  );
+  assertStringIncludes(
+    copy,
+    "La query n'est pas contrainte par les scopes : tous les paramètres passent.",
+  );
+});
+
+Deno.test("§12.13: la note query n'a pas de titre", () => {
+  const note = elementHtml("test-query-note", "</p>");
+
+  // Le niveau passe par l'icone et la couleur ; un titre ne porterait aucune information et
+  // ferait sortir le bloc de son budget de hauteur.
+  assertEquals(note.includes("<strong"), false, "titre en gras dans la note query");
+  assertEquals(/<h[1-6]\b/.test(note), false, "titre de section dans la note query");
+  assertEquals(note.includes("font-semibold"), false, "titre appuye dans la note query");
+
+  // L'icone est decorative : la gravite doit rester deductible du texte seul.
+  assertStringIncludes(note, 'aria-hidden="true"');
 });


### PR DESCRIPTION
Dernière étape du lot sécurité : la documentation utilisateur n'avait pas suivi les ADR-0009 et ADR-0010, mergés en #13.

## Ce que ça corrige

Cinq codes d'erreur existaient dans le code sans exister nulle part pour leur porteur. Dix changements cassants n'étaient annoncés qu'en ADR. Et la non-contrainte des paramètres de query, qui est la seule non-garantie contredisant la promesse du produit, n'était écrite qu'au fond d'une section d'ADR.

## Documentation

`docs/specs.md` gagne une section 18 sur la politique de sortie et les limites de ressources. Les cinq codes sont répartis selon la frontière existante : `unsupported_regex`, `target_forbidden` et `payload_too_large` avec les erreurs de la route proxy, `invalid_target` et `invalid_scope` avec les endpoints internes, puisqu'ils se produisent à la génération et pas à la consommation.

`docs/limits.md` gagne onze plafonds et une section 11 qui expose le critère de dimensionnement : aucune primitive optionnelle ne doit coûter plus cher que la dérivation PBKDF2 obligatoire, soit 11,6 ms.

Le README et les deux guides de déploiement documentent `FGP_EGRESS_ALLOW_PRIVATE` avec sa conséquence dite sans euphémisme, et la limitation de débit côté opérateur, qui reste hors de l'application parce qu'un limiteur en mémoire est inopérant sur Deno Deploy.

Le changelog annonce dix changements cassants, pas sept. Les trois ajoutés sont les cibles non publiques refusées, les redirections non suivies et le 413 : les ADR les listent comme cassants et un utilisateur les rencontre dès la mise à jour.

## Interface et /llms.txt

Le panneau Doc porte les trois codes manquants et un nouveau groupe pour `target_forbidden`. Le bloc sur la query est placé hors du `<details>` : ce n'est pas une erreur mais une absence de refus, personne ne la chercherait dans une liste de codes.

Le testeur de scopes affiche une note dès que le chemin porte un `?`. Elle est pilotée par `verdict.queryConstrained`, donc elle disparaîtra d'elle-même quand `queryFilters` arrivera, sans qu'on ait à la retrouver.

`/llms.txt` liste les quinze codes et affirme les trois non-garanties de sortie.

## Vérification

`deno task verify` vert, 650 tests, 0 échec. Un test extrait les codes de `/llms.txt` et exige que le panneau Doc les porte tous avec leur status : une divergence future casse le build.