### PR TITLE
docs: resynchronise CLAUDE.md et le plan de sortie avec le code livre

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,10 @@
 - **TTL** : expiration encodée dans le blob, vérifiée à chaque requête.
 - **6 modes d'auth** : bearer, basic, header custom simple, headers multiples, Scalingo API (exchange), Scalingo Database API (exchange + token d'addon). Scalingo est un cas d'usage parmi d'autres.
 - **Blob v2/v3/v4** : v2 = scopes string METHOD:PATH, v3 = scopes mixtes string + ScopeEntry avec body filters, v4 = champ `auth` structuré (`string | AuthSpec`). Les trois versions restent déchiffrables, v4 n'est produit que si `auth` est un objet.
-- **Body filters** (v3) : filtrage du contenu JSON des requêtes POST/PUT/PATCH (types : any, wildcard, stringwildcard, regex, not, and).
+- **Body filters** (v3) : filtrage du contenu JSON des requêtes POST/PUT/PATCH (types : any, wildcard, stringwildcard, regex, not, and). `any` n'accepte qu'un scalaire, comparer un objet dépendrait de l'ordre des clés de l'appelant. `regex` est un dialecte restreint (ADR-0010), pas une RegExp libre. Les plafonds vivent en double, `src/middleware/scope-limits.ts` à la génération pour un message actionnable et `src/crypto/blob.ts` au déchiffrement pour refuser un blob forgé. Le salt étant public, seul le second protège : toujours modifier les deux.
 - **Logs stream** (ADR-0007) : page `/logs` avec SSE live par blob, opt-in via champ `logs: { enabled, detailed }` dans le blob (décorrélé de la version du blob). In-memory only (ring buffer par blob + purge inactivité), body `detailed` chiffré AES-256-GCM côté serveur avec la clé client (zero trust). Kill switch global `FGP_LOGS_ENABLED`.
+- **Politique de sortie** (ADR-0009) : contrat unique sur tout ce qui sort du processus. `src/net/egress.ts` est le seul point de sortie et le seul `fetch` du code serveur. Destination publique obligatoire, chemin contrôlé sur la forme brute et la forme canonique mais émis en brut, authentification issue du blob et jamais de l'appelant, `redirect: "manual"` partout. Les paramètres de query ne sont contraints par aucun scope, et l'outillage doit le dire au lieu d'affirmer un refus que le proxy n'applique pas.
+- **Limites de ressources** (ADR-0010) : chaque coût est borné avant d'être payé. Blob plafonné à 4096 caractères et refusé sous 64, décompression bornée à 128 Ko en sortie, corps proxy bufferisé à 512 Ko et seulement quand un body filter ou la capture `detailed` en a besoin, `bodyLimit` monté sur la liste explicite des chemins `/api/*` et **jamais sur `*`**, cache LRU de dérivation PBKDF2. Le critère de calibrage est unique : aucune primitive optionnelle ne doit coûter plus cher que la dérivation PBKDF2 obligatoire, soit 11,6 ms.
 
 ## Stack
 - **Runtime** : Deno
@@ -44,22 +46,40 @@
 - `deno task check` : type checking serveur, puis `check:client`
 - `deno task check:client` : type checking du code navigateur via `deno.client.json` (lib DOM isolée, pour ne pas affaiblir le check serveur)
 - `deno task verify` : lint + fmt + check + test (pipeline complète)
+- **Permissions** : `dev:server`, `start` et les quatre tâches `test*` tournent sur une allow-list explicite de variables, jamais `--allow-env` nu. Ajouter une variable d'environnement lue par le serveur, c'est toucher trois endroits : la section « Variables d'environnement » ci-dessous, les six listes `--allow-env` de `deno.json`, et `.env.example`. Oubliée dans `deno.json`, elle lève une erreur de permission au runtime comme en test au lieu de prendre son défaut. Élargir la permission pour faire taire l'erreur annule le durcissement.
 
 ## Structure
 ```
 src/
   main.ts           point d'entrée, Hono app, Deno.serve sous import.meta.main
   constants.ts      constantes partagées (FGP_SOURCE_HEADER, FGP_OWNED_PATHS, FGP_SECURITY_HEADERS)
-  routes/           routes Hono (ui.tsx, logs.tsx, llms.ts)
-  middleware/       middlewares (proxy, scopes, body filters, capture logs)
-  crypto/           blob.ts (chiffrement/déchiffrement), client-key.ts (validation clé), share.ts
+  routes/           ui.tsx : page de config, TOUS les endpoints /api/* et la route /llms.txt.
+                    logs.tsx : /logs, /logs/stream, /logs/health. llms.ts : pas de route,
+                    seulement le rendu du contenu servi sur /llms.txt
+  net/              egress.ts : point de sortie unique du processus (ADR-0009). parseTargetUrl
+                    (forme), classifyLiteralHost (moitié synchrone de la classification),
+                    assertPublicHost (classification complète, avec DNS), buildUpstreamUrl,
+                    egressFetch. Jamais de fetch nu côté serveur
+  middleware/       proxy.ts (flow proxy), scopes.ts (matching méthode/chemin et body filters),
+                    scope-limits.ts (limites de scopes et dialecte regex, refus à la génération)
+  crypto/           blob.ts (chiffrement/déchiffrement), client-key.ts (validation clé), share.ts,
+                    bounded.ts (décompression plafonnée), key-cache.ts (cache des clés dérivées),
+                    regex-policy.ts (dialecte regex restreint et ancrage, ADR-0010)
   auth/             spec.ts (AuthSpec + validation), credentials.ts, client.ts (Scalingo), cache.ts
-  logs/             feature /logs : config env, blob-id, capture, events, ip, store (ring buffer in-memory)
-  ui/               pages JSX (config-page, layout, logo/SEO, logs-page)
+  logs/             feature /logs : config env, blob-id, capture (captureNetwork et
+                    captureDetailed, pas dans middleware/), events, ip, store (ring buffer)
+  ui/               config-page.tsx (assemble les composants de ui/config/), layout.tsx (logo,
+                    SEO), logs-page.tsx, asset-version.ts (cache-busting via static/version.txt),
+                    changelog-renderer.tsx, changelog-data.ts (généré, ne pas éditer)
+  ui/config/        composants de la page de config : form-identity, form-auth, form-scopes,
+                    form-delivery, result, sidebar (+ sidebar-doc, sidebar-guides,
+                    sidebar-panels), page-chrome, icons, constants
   ui/client/        modules TS client (auth-mode, auth-headers, addons, byok, presets, body-filters,
                     apps, generate, ttl, clipboard, scopes, test-scope, share-config, import-config,
                     tabs, logs-tab, elements, types)
   ui/tailwind.css   source Tailwind (build-time vers static/styles.css)
+scripts/            version.ts (SHA de build vers static/version.txt), changelog.ts (génère
+                    src/ui/changelog-data.ts depuis docs/changelog.md)
 deno.client.json    config de type checking du code navigateur (lib DOM)
 tailwind.config.js  config Tailwind (couleurs fgp, dark mode media)
 static/             assets compilés (client.js, styles.css), gitignored
@@ -82,34 +102,56 @@ docs/
 - Pas de default exports sauf `src/main.ts`
 - Imports triés : deps externes, puis internes, ligne vide entre les deux
 - Nommage : camelCase pour variables/fonctions, PascalCase pour types/interfaces
-- Erreurs : utiliser `HTTPException` de Hono pour les erreurs HTTP
-- OpenAPI : schemas de réponse stricts par route (union `z.enum([...])` des error codes autorisés). Ajouter un nouveau code d'erreur = l'ajouter dans l'enum de la route correspondante, **quand la route est documentée**. Seules les routes `/api/*` le sont : la route proxy `/{blob}/*` n'apparaît pas dans l'OpenAPI, puisque son contrat dépend entièrement du blob. Ses codes d'erreur vivent donc dans `docs/specs.md` et dans `/llms.txt`, qui doivent être mis à jour à la place.
+- Erreurs : **jamais `HTTPException`**. `app.onError` (`src/main.ts`) ne la discrimine pas et la transformerait en 500 `internal_error`, perdant le status et le code voulus. Renvoyer la shape `{error, message}` par les helpers locaux : `jsonError` (`src/middleware/proxy.ts`), `jsonStreamError` (`src/routes/logs.tsx`), `c.json({ error, message }, status)` dans `src/routes/ui.tsx`.
+- OpenAPI : schemas de réponse stricts par route (union `z.enum([...])` des error codes autorisés). Ajouter un nouveau code d'erreur = l'ajouter dans l'enum de la route correspondante, **quand la route est documentée**. Seules les routes `/api/*` le sont : la route proxy `/{blob}/*` n'apparaît pas dans l'OpenAPI, puisque son contrat dépend entièrement du blob. Ses codes d'erreur vivent donc dans `docs/specs.md` et dans `/llms.txt`, qui doivent être mis à jour à la place. Un code produit par un **middleware monté** sur la route compte comme un code de cette route : `createRoute` ne le voit pas tout seul, et le 413 `payload_too_large` d'`apiBodyLimit` manque aujourd'hui dans les enums de tous les `/api/*`.
 - Toute réponse du proxy principal doit porter `X-FGP-Source: proxy|upstream` (voir `src/constants.ts`).
+- **Réseau sortant** : tout appel serveur passe par `egressFetch` de `src/net/egress.ts`, jamais par un `fetch` direct. Une URL cible se valide par `parseTargetUrl` et se construit par `buildUpstreamUrl`, jamais par concaténation. Un `fetch` nu côté serveur rouvre la SSRF que l'ADR-0009 ferme. Les `fetch` du code navigateur visent FGP lui-même et ne sont pas concernés.
+- **Expressions régulières issues d'une entrée** : jamais `new RegExp` en direct. Valider la source par `checkRegexSource` puis compiler par `compileAnchored` (`src/crypto/regex-policy.ts`). Non validée, la regex rouvre le ReDoS ; non ancrée, elle matche en sous-chaîne et autorise plus que son motif (ADR-0010).
+- **Autorisation d'une requête** : `checkRequestAccess` (`src/middleware/scopes.ts`) est la seule porte. Ne jamais appeler `checkAccess` directement depuis la route proxy ni depuis l'UI : il ne contrôle qu'une seule forme du chemin et retire silencieusement la garantie de l'ADR-0009. Une seule lecture des scopes, sinon l'interface finit par affirmer un refus que la production n'applique pas.
 - Exploration du code TypeScript : LSP en priorité (`workspaceSymbol`, `findReferences`, `goToDefinition`), grep en dernier recours. Le LSP suit les alias et les re-exports, grep ne fait que du pattern matching.
 
 ## Flow proxy
 ```
 Requête, extraire blob (header X-FGP-Blob prioritaire, sinon premier segment URL)
   vérifier taille blob, extraire X-FGP-Key
-  PBKDF2(client_key + server_salt), déchiffrer blob (gunzip + AES-256-GCM)
-  valider auth mode, vérifier TTL
-  parser body si body filters requis (POST/PUT/PATCH + JSON)
-  vérifier scopes vs méthode/path/body
-  obtenir les credentials (toujours APRÈS la vérification des scopes, pour qu'un appelant
-    hors scope ne déclenche aucun appel réseau et n'apprenne rien de la config)
-  forward vers config.target avec auth headers (X-FGP-Key et X-FGP-Blob strippés)
-  renvoyer réponse upstream telle quelle (status/body/headers, seul Set-Cookie strippé)
+  pré-filtre gratuit avant PBKDF2 : format de la clé et plancher structurel du blob (64 chars),
+    pour ne pas payer la dérivation sur une sonde malformée
+  PBKDF2(client_key + server_salt) servi par le cache de dérivation, déchiffrer blob
+    (gunzip borné + AES-256-GCM). Un blob déchiffrable mais hors politique (regex hors
+    dialecte) sort en 400 unsupported_regex, jamais en 401 : le diagnostic doit désigner
+    le blob, pas la clé
+  vérifier le TTL, puis valider le mode d'auth
+  lire le corps de façon bornée si un body filter ou la capture detailed le réclame
+    (POST/PUT/PATCH + JSON), dépassement en 413 payload_too_large. Sans ces deux besoins
+    le corps n'est jamais bufferisé et part en flux, ne jamais casser cette propriété
+  vérifier les scopes via checkRequestAccess : méthode, corps, et le chemin sur DEUX formes,
+    brute et canonique. Les deux doivent être autorisées, la forme émise reste la brute.
+    La query n'est contrainte par aucun scope, elle est transmise telle quelle
+  classifier la destination : parseTargetUrl (forme) puis assertPublicHost (adresse publique
+    après résolution DNS), refus en 403 target_forbidden
+  obtenir les credentials
+  ces deux dernières étapes sont toujours APRÈS la vérification des scopes, pour qu'un appelant
+    hors scope ne déclenche ni résolution DNS ni appel réseau et n'apprenne rien de la config
+  forward vers config.target : strip des en-têtes de l'appelant (denylist par classe : hop-by-hop,
+    Authorization, Cookie, provenance, Host, X-FGP-*), PUIS pose des en-têtes d'auth du blob.
+    Cet ordre est imposé, l'inverser supprimerait l'Authorization légitime issue du blob
+  renvoyer réponse upstream telle quelle (status/body/headers, seul Set-Cookie strippé).
+    Les redirections ne sont pas suivies, un 3xx est forwardé tel quel avec son Location :
+    sans cela la classification de destination ne vaut rien
 ```
 
 **Proxy transparent (ADR-0006)** : toute réponse effectivement reçue de l'upstream est forwardée sans transformation, avec header `X-FGP-Source: upstream`. Les erreurs générées par FGP lui-même portent `X-FGP-Source: proxy` et la shape `{error, message}`. Trois 502 sont légitimes côté proxy : `upstream_unreachable` (fetch throw), `auth_exchange_failed` (échange de token Scalingo échoué) et `auth_addon_failed` (obtention du token d'addon échouée). Les 500 non catchés passent par `app.onError` dans `src/main.ts` vers la shape FGP `{error: "internal_error", ...}`. Ne jamais réintroduire de transformation de status/body upstream.
 
 **En-têtes de sécurité** : montés sur la liste explicite `FGP_OWNED_PATHS`, **jamais sur `*`**, plus un wrapper qui couvre les erreurs FGP de la route proxy (discriminées par `X-FGP-Source: proxy`). La transparence de l'ADR-0006 est ainsi garantie par construction et non par une condition qui peut se tromper. La couverture est vérifiée par un test de recensement des routes réellement enregistrées, et la parité entre `FGP_SECURITY_HEADERS` et ce que servent les routes par un test dédié. Ne jamais remonter ce middleware sur un pattern fourre-tout.
 
+**Plafonds de corps (ADR-0010)** : `bodyLimit` est monté sur des chemins `/api/*` explicites, **jamais sur `*`**, même doctrine que les en-têtes de sécurité et pour un enjeu plus lourd. La route proxy transmet le corps en streaming, un plafond global le mettrait en tampon et casserait les uploads volumineux légitimes à travers le proxy, en introduisant précisément la consommation mémoire qu'on cherche à éviter.
+
 **Carve-out `/logs`** : `blobHeaderProxy()` exclut `/logs` et `/logs/*` du mode header. C'est nécessaire, la feature logs consomme elle-même `X-FGP-Blob` et `X-FGP-Key` pour identifier le blob à streamer. Sans cette exclusion, `/logs/stream` serait injoignable. `/llms.txt` n'est en revanche pas exclu et reste proxyfiable.
 
 ## Variables d'environnement
 - `PORT` : port du serveur (défaut: 8000). Réellement pris en compte depuis le passage à `Deno.serve()` explicite.
 - `FGP_SALT` : salt serveur pour la dérivation de clé (requis)
+- `FGP_EGRESS_ALLOW_PRIVATE` : interrupteur de **développement uniquement**, désactivé par défaut. `1` coupe la classification des destinations (ADR-0009), jamais le contrôle de forme du `target` ni le `redirect: "manual"`. Actif en production, la garantie de destination tombe et l'instance redevient une SSRF non authentifiée, ouverte sur le réseau privé de l'hébergeur et sur son service de métadonnées. L'avertissement console est écrit au premier contrôle de destination, pas au démarrage : une instance qui n'a encore rien proxyfié reste silencieuse.
 - `SCALINGO_API_URL` : URL de l'API Scalingo pour les helpers list-apps et list-addons, et pour l'obtention du token d'addon (défaut: https://api.osc-fr1.scalingo.com)
 - `SCALINGO_AUTH_URL` : URL du service auth Scalingo pour l'échange de token (défaut: https://auth.scalingo.com)
 - `FGP_GITHUB_REPO` : repo GitHub `owner/name` pour la résolution du SHA de build (défaut: auto-détecté via git remote ou `lsagetlethias/fine-grained-proxy`)
@@ -118,6 +160,7 @@ Requête, extraire blob (header X-FGP-Blob prioritaire, sinon premier segment UR
 - `FGP_LOGS_BUFFER_DETAILED` : taille du ring buffer des entries detailed (body chiffré) par blob (défaut: 10)
 - `FGP_LOGS_INACTIVITY_MIN` : minutes d'inactivité avant purge complète du buffer d'un blob (défaut: 10)
 - `FGP_LOGS_DETAILED_MAX_KB` : taille max du body capturé en detailed, en KB, avant troncature (défaut: 32)
+- `FGP_TRUSTED_PROXY_HOPS` : nombre de sauts de proxy amont dignes de confiance pour l'IP capturée dans les logs (défaut: 0). À `0`, `X-Forwarded-For` et `X-Real-IP` sont ignorés et l'IP est celle du pair. Au-dessus, l'IP retenue est la n-ième de `X-Forwarded-For` en partant de la droite, jamais la première : la partie gauche est écrite par l'appelant. Toute valeur non entière ou négative retombe sur `0`.
 
 ## Équipe multi-agent
 - **Référence complète** : `docs/ia-architecture-reference.md` (setup, rôles, modèles, skills, hooks, process type, workflows)
@@ -127,7 +170,7 @@ Requête, extraire blob (header X-FGP-Blob prioritaire, sinon premier segment UR
   - `testeur.md` (`opus`) : challenge specs, AC Given/When/Then, /add-tests, /verif
   - `designer.md` (`sonnet`) : specs UI/UX dans docs/design/, review a11y, PAS d'intégration
   - pas de définition pour le lead : c'est la session principale
-- **Fiches de poste** dans `docs/team/` : doc humaine (place dans le process, interactions) et source de vérité des **checklists de fin de tâche**, que le hook de commit audite. Partage détaillé en section 4.2 de la référence.
+- **Fiches de poste** dans `docs/team/` : doc humaine (place dans le process, interactions) et source de vérité des **checklists de fin de tâche**. Le hook de commit ne les audite plus : un sous-agent n'a accès ni au transcript parent ni à celui de ses frères, il concluait donc systématiquement à l'absence et bloquait à tort. Il ne vérifie plus que ce qui est vérifiable depuis le diff, et autorise en cas de doute. Les checklists restent à la charge de chaque rôle et du lead. Partage détaillé en section 4.2 de la référence.
 - **Avant de dispatcher** : ne plus recopier la fiche dans le brief. Lancer l'agent par son type (`subagent_type: "dev"`) et ne mettre dans le brief que la tâche et son contexte.
 - **Parallélisme** : `isolation: "worktree"` dès que deux agents parallèles écrivent dans le même fichier, plutôt que de les séquencer.
 - **Review** : renvoyer les remarques au même agent par continuation, pas re-spawner un agent vierge.
@@ -142,6 +185,6 @@ Requête, extraire blob (header X-FGP-Blob prioritaire, sinon premier segment UR
 - **OpenAPI** : `GET /api/openapi.json`, spec OpenAPI 3.0 auto-générée depuis le code (schemas Zod)
 - **Swagger UI** : `GET /api/docs`, documentation interactive de l'API
 - **llms.txt** : `GET /llms.txt`, documentation en anglais destinée aux agents LLM (convention llmstxt.org), découvrable par balise `<link rel="describedby">` et header HTTP `Link`
-- **ADR** dans `docs/adr/`, pour les décisions architecturales significatives
+- **ADR** dans `docs/adr/`, pour les décisions architecturales significatives. Deux d'entre eux contraignent le code avant même de l'écrire et se lisent avant de toucher au réseau ou à une limite : **ADR-0009** (politique de sortie du proxy) et **ADR-0010** (politique de limites de ressources).
 - **ACTIVITY.md** : log d'activité des sessions de dev
-- **MEMORY.md** : mémoire persistante Claude Code
+- **MEMORY.md** : mémoire persistante Claude Code, **hors dépôt**, sous `~/.claude/projects/<projet>/memory/`. Ne pas la chercher dans les fichiers versionnés.

--- a/docs/review/plan-politique-sortie.md
+++ b/docs/review/plan-politique-sortie.md
@@ -241,9 +241,9 @@ C'est l'étape qui matérialise la frontière de périmètre. Trois changements,
 
 **Ce qui ne change pas, volontairement** : aucun `queryFilters`, aucune version de blob, aucune nouvelle structure de scope. Voir « Hors lot ».
 
-**Tests** : `tests/testi/test-scope.test.ts` (existant, à étendre), `tests/testi/api.test.ts` (existant, à étendre).
-- AC-46.1 : `POST /api/test-scope` avec `path: "/v1/items?action=delete"` et scope `GET:/v1/items` renvoie `allowed: true` et un indicateur de query non contrainte. C'est le correctif du mensonge fail-open, et c'est le test le plus important de l'étape.
-- AC-46.2 : le verdict de l'endpoint est identique à celui du proxy sur une table de cas partagée, chemins percent-encodés inclus. Garde-fou anti-divergence, il doit exister même s'il paraît redondant.
+**Tests** : `tests/testi/test-scope.test.ts` (existant, à étendre), `tests/testi/api.test.ts` (existant, à étendre). `tests/testi/test-scope.test.ts` a disparu avec l'endpoint, la couverture correspondante vit en test unitaire.
+- AC-46.1 : `POST /api/test-scope` avec `path: "/v1/items?action=delete"` et scope `GET:/v1/items` renvoie `allowed: true` et un indicateur de query non contrainte. C'est le correctif du mensonge fail-open, et c'est le test le plus important de l'étape. **Reformulé après la suppression de l'endpoint** : le même cas est couvert en unitaire sur `checkRequestAccess`, qui est ce que le testeur client appelle désormais.
+- AC-46.2 : le verdict de l'endpoint est identique à celui du proxy sur une table de cas partagée, chemins percent-encodés inclus. Garde-fou anti-divergence, il doit exister même s'il paraît redondant. **Sans objet après la suppression de l'endpoint** : il n'existe plus deux implémentations du verdict à comparer, ce qui est la forme forte de la garantie que ce critère visait.
 - AC-46.3 : `deno task check:client` passe, la fonction partagée compile côté navigateur.
 - AC-46.4 : `POST /api/generate` avec un scope `GET:/v1/items?safe=1` renvoie 400 `invalid_scope`.
 - AC-46.5 : un blob existant portant un tel pattern se déchiffre toujours, et le pattern ne matche jamais (non-régression, aucun blob invalidé).

--- a/docs/review/plan-politique-sortie.md
+++ b/docs/review/plan-politique-sortie.md
@@ -40,7 +40,12 @@ export function parseTargetUrl(raw: string): { url: URL } | { error: EgressDenia
 // Étape 2 : classification d'une adresse littérale.
 export function isBlockedAddress(ip: string): boolean;
 
-// Étape 2 : classification d'un hôte, avec résolution si c'est un nom.
+// Étape 2, moitié synchrone : IP littérale et suffixes conventionnels, sans réseau.
+// Destinée aux chemins qui n'émettent aucune requête, la génération en particulier.
+export function classifyLiteralHost(hostname: string): EgressDenial | null;
+
+// Étape 2 complète : classifyLiteralHost, puis résolution DNS des noms.
+// À n'appeler que sur un chemin qui va réellement émettre.
 export async function assertPublicHost(hostname: string): Promise<EgressDenial | null>;
 
 // Point de sortie unique : parseTargetUrl + assertPublicHost + fetch(redirect: "manual").
@@ -60,6 +65,12 @@ Règles à implémenter, toutes détaillées dans l'ADR §2 :
 - échec de résolution : **pas** un refus, on laisse passer et `fetch` échouera en `upstream_unreachable` ;
 - `FGP_EGRESS_ALLOW_PRIVATE=1` désactive l'étape 2 uniquement, avec un `console.warn` au premier appel ;
 - `redirect: "manual"` sur tous les appels sortants.
+
+**L'étape 2 est scindée en deux, et c'est structurant.** La partie synchrone se décide sur la chaîne seule, IP littérale et suffixes conventionnels, sans toucher au réseau. La partie DNS exige une résolution et ne peut donc vivre qu'au point de sortie, juste avant le `fetch`.
+
+Cette scission n'est pas un détail d'implémentation, elle répond à deux contraintes opposées. Une classification faite trop tôt ne vaut rien : la réponse DNS obtenue à la génération d'un blob aura expiré bien avant son premier usage, et prétendre avoir validé la destination à ce moment-là serait une garantie fausse. Mais une classification faite uniquement au point de sortie laisserait passer sans le moindre signal un `target` qui est déjà, littéralement, `http://169.254.169.254`, alors que rien n'oblige à attendre une requête pour le refuser.
+
+D'où le partage : la génération applique `classifyLiteralHost` et refuse ce qui est refusable sur la chaîne, le point de sortie applique `assertPublicHost` et refuse ce qui n'était connaissable qu'après résolution. Et même au bon endroit, cette seconde moitié ne protège pas du rebinding DNS : entre la résolution de contrôle et celle du `fetch`, rien ne garantit la même réponse. La défense réelle contre le rebinding est le filtrage d'egress au niveau réseau, au déploiement.
 
 **Tests** : `tests/testu/net/egress.test.ts` (nouveau), résolveur injecté, échappatoire désactivée.
 - AC-43.1 schéma : `file:`, `data:`, `ftp:`, `javascript:` refusés en `invalid_target`.
@@ -94,7 +105,7 @@ Règles à implémenter, toutes détaillées dans l'ADR §2 :
 **Fichier** : `src/routes/ui.tsx`.
 
 **Ce qui change** :
-- `/api/generate` : `parseTargetUrl(body.target)` avant chiffrement, 400 `invalid_target` en cas de refus. Nouveau code d'erreur à ajouter à l'enum de réponse de la route (convention CLAUDE.md).
+- `/api/generate` : `parseTargetUrl(body.target)` **puis** `classifyLiteralHost(url.hostname)` avant chiffrement, 400 `invalid_target` si l'un des deux refuse. `parseTargetUrl` seule ne suffit pas, elle ne classe aucune adresse et `http://169.254.169.254` en sort valide. Pas d'`assertPublicHost` ici : l'endpoint n'émet aucune requête, et une résolution faite à la génération aura expiré au premier usage du blob. Nouveau code d'erreur à ajouter à l'enum de réponse de la route (convention CLAUDE.md).
 - `/api/test-proxy` : la requête sortante passe par `egressFetch` et `buildUpstreamUrl`. Refus de politique renvoyé dans la forme existante de l'endpoint, `{ allowed: true, reason: "target_forbidden" }`, pour ne pas changer la shape de réponse.
 - `/api/list-apps` et `/api/list-addons` : le champ `target` fourni par l'appelant doit avoir un hôte en `.scalingo.com`, sinon 400 `invalid_target`. La valeur issue de `SCALINGO_API_URL` n'est pas soumise à cette règle.
 
@@ -110,7 +121,7 @@ Règles à implémenter, toutes détaillées dans l'ADR §2 :
 
 **Fichier** : `src/auth/client.ts`, fonctions `resolveScalingoApiUrl` et `fetchAddonToken`.
 
-**Ce qui change** : `fetchAddonToken` vérifie que l'hôte résolu se termine par `.scalingo.com` avant d'émettre, et passe par `egressFetch`. Le refus lève, ce qui remonte en 502 `auth_addon_failed` par le chemin existant de `src/middleware/proxy.ts`. Idem pour la validation à la génération : un `AuthSpec` `scalingo-addon` dont l'`apiUrl` n'est pas Scalingo est refusé en 400 `invalid_body` par `validateAuthSpecShape`.
+**Ce qui change** : `fetchAddonToken` vérifie que l'hôte résolu se termine par `.scalingo.com` avant d'émettre, et passe par `egressFetch`. Le refus lève, ce qui remonte en 502 `auth_addon_failed` par le chemin existant de `src/middleware/proxy.ts`. Idem **prévu** pour la validation à la génération : un `AuthSpec` `scalingo-addon` dont l'`apiUrl` n'est pas Scalingo doit être refusé en 400 `invalid_body` par `validateAuthSpecShape`. **Non livré, et il faut le lire comme tel** : `validateAuthSpecShape` ne contrôle que la forme de l'`apiUrl`, chaîne non vide et préfixe `https://`. La contrainte d'hôte n'existe qu'à l'exécution, dans `fetchAddonToken`. Le bearer ne part donc nulle part, mais un blob à `apiUrl` hostile se génère sans erreur et n'échoue qu'au premier appel, en 502. AC-43.18 reste ouvert.
 
 **Justification** : ce mode est spécifique à Scalingo par construction (ADR-0008). La contrainte d'agnosticisme porte sur `target`, pas sur un mode d'auth propriétaire.
 
@@ -132,7 +143,7 @@ export function canonicalizePath(rawPath: string): string;
 
 export interface AccessVerdict {
   allowed: boolean;
-  denialReason?: "method" | "path" | "path_encoded" | "body" | "query";
+  denialReason?: "method" | "path" | "path_encoded" | "body" | "query" | "invalid_path";
   queryConstrained: boolean;   // toujours false dans ce lot, voir « Hors lot »
 }
 
@@ -219,6 +230,8 @@ export function checkRequestAccess(
 C'est l'étape qui matérialise la frontière de périmètre. Trois changements, aucun ne touche au blob.
 
 **Fichiers** : `src/routes/ui.tsx` (`/api/test-scope` et `/api/generate`), `src/middleware/scope-limits.ts`, `src/ui/client/test-scope.ts`, `src/ui/config/form-scopes.tsx` (copie du verdict).
+
+**Périmé depuis l'ADR-0010** : `/api/test-scope` a été supprimée, elle répond 404 et ne figure plus dans l'OpenAPI. Le test de scope est devenu purement client, `src/ui/client/test-scope.ts` important `checkRequestAccess` directement. AC-46.2 n'a donc plus d'objet : il n'existe plus deux implémentations du verdict à comparer, ce qui est la forme forte de la garantie anti-divergence que cette étape visait. Le reste de l'étape est inchangé.
 
 **Ce qui change** :
 


### PR DESCRIPTION
`CLAUDE.md` n'avait pas bougé depuis la feature `/logs`. Les lots ADR-0009 et ADR-0010 ont introduit un point de sortie réseau unique, un dialecte de regex et des plafonds de ressources dont le fichier ne disait rien. C'est le document que chaque agent lit avant d'écrire une ligne, donc chaque dérive s'y paie en code faux.

Audit sur les huit sections du fichier, 42 dérives signalées, 32 confirmées après une passe de réfutation.

## Les cinq qui coûtaient le plus cher

`src/net/egress.ts` n'apparaissait nulle part, ni le répertoire, ni `egressFetch`, ni la règle. Un agent à qui on demande un appel réseau écrivait `fetch()` nu et rouvrait la SSRF que le lot vient de fermer.

« Erreurs : utiliser `HTTPException` de Hono » était une convention que le code ne suit nulle part. La seule occurrence de `HTTPException` dans tout le dépôt était cette ligne de `CLAUDE.md`, et un agent qui l'aurait suivie aurait vu son erreur écrasée en 500 `internal_error` par `app.onError`.

Le pseudo-code du flow proxy ignorait quatre étapes de sécurité ajoutées par le lot, et annonçait l'ordre TTL et mode d'auth à l'envers de ce que fait le code.

Les deux variables d'environnement du lot manquaient. Et rien ne disait qu'une variable oubliée dans les six listes `--allow-env` de `deno.json` lève une erreur de permission au runtime au lieu de prendre son défaut.

L'arborescence ignorait `src/net/`, `src/ui/config/`, `scripts/` et trois modules de `crypto/`, et plaçait la capture des logs dans `middleware/` où elle n'est pas.

## Le plan de la politique de sortie

Il gagne l'explication que le dev réclamait : l'étape 2 est scindée en une moitié synchrone appliquée à la génération et une moitié DNS appliquée au point de sortie. Le plan disait qu'elle existait sans dire pourquoi. Une classification faite trop tôt a expiré avant le premier usage du blob, une classification faite seulement au point de sortie laisse passer sans signal un `target` qui est déjà littéralement une adresse de métadonnées.

Deux affirmations que l'implémentation contredit sont corrigées plutôt que laissées : `parseTargetUrl` ne classe aucune adresse, et la contrainte d'hôte sur l'`apiUrl` Scalingo n'existe pas à la génération, seulement à l'exécution.

## Deux défauts trouvés en passant, non corrigés ici

Le 413 `payload_too_large` d'`apiBodyLimit` frappe tous les `/api/*` mais ne figure dans l'enum de réponse d'aucune route : la spec OpenAPI servie ne le déclare nulle part. La convention est écrite dans `CLAUDE.md` pour que ça ne se reproduise pas, la correction des enums reste à faire.

Un `AuthSpec` `scalingo-addon` dont l'`apiUrl` n'est pas Scalingo se génère sans erreur et n'échoue qu'au premier appel, en 502. Le bearer ne part nulle part, donc ce n'est pas une fuite, mais le diagnostic arrive trop tard. AC-43.18 reste ouvert.

## Vérification

`deno task verify` vert, 650 tests, 0 échec. Aucun fichier de `src/` touché.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded project guidance for request filtering, exit policies, resource limits, permissions, environment variables, proxy behavior, and body-size limits.
  - Updated architecture and code conventions, including error responses, regex validation, access checks, and outbound request handling.
  - Revised the exit-policy implementation plan with clearer host classification, DNS-rebinding considerations, validation behavior, and denial reasons.
  - Documented that the `/api/test-scope` endpoint is no longer available and has been removed from the OpenAPI specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->