### PR TITLE
fix(scopes): evalue les body filters une seule fois sur les deux formes de chemin

### DIFF
--- a/src/middleware/scopes.ts
+++ b/src/middleware/scopes.ts
@@ -132,37 +132,60 @@ export function matchBodyFilter(filter: BodyFilter, body: unknown): boolean {
   return filter.objectValue.some((ov) => matchObjectValue(ov, value));
 }
 
+type BodyDecision = "allow" | "skip" | "deny";
+
+function decideBodyFilters(scope: ScopeEntry, body: unknown): BodyDecision {
+  if (!scope.bodyFilters || scope.bodyFilters.length === 0) return "allow";
+  if (body === undefined) return "deny";
+  return scope.bodyFilters.every((f) => matchBodyFilter(f, body)) ? "allow" : "skip";
+}
+
+type PathMatcher = (method: string, path: string) => boolean;
+
+// Ce qui ne depend pas de la forme du chemin, aujourd'hui les filtres de corps, est decide
+// une fois par scope et partage entre les passes de checkRequestAccess. Sans ce partage,
+// l'appelant declenche la seconde passe en envoyant un chemin non canonique et fait payer
+// deux fois le budget d'evaluation calibre par l'ADR-0010 D2.
+function createPathMatcher(scopes: Scope[], body: unknown): PathMatcher {
+  const bodyDecisions: (BodyDecision | undefined)[] = [];
+
+  return (method, path) => {
+    const upperMethod = method.toUpperCase();
+
+    for (let i = 0; i < scopes.length; i++) {
+      const scope = scopes[i];
+
+      if (typeof scope === "string") {
+        const parsed = parseScope(scope);
+        const methodMatch = parsed.methods.includes("*") || parsed.methods.includes(upperMethod);
+        if (methodMatch && matchPath(parsed.pattern, path)) return true;
+        continue;
+      }
+
+      const methodMatch = scope.methods.some((m) => m === "*" || m.toUpperCase() === upperMethod);
+      if (!methodMatch) continue;
+      if (!matchPath(scope.pattern, path)) continue;
+
+      let decision = bodyDecisions[i];
+      if (decision === undefined) {
+        decision = decideBodyFilters(scope, body);
+        bodyDecisions[i] = decision;
+      }
+      if (decision === "allow") return true;
+      if (decision === "deny") return false;
+    }
+
+    return false;
+  };
+}
+
 export function checkAccess(
   scopes: Scope[],
   method: string,
   path: string,
   body?: unknown,
 ): boolean {
-  const upperMethod = method.toUpperCase();
-
-  for (const scope of scopes) {
-    if (typeof scope === "string") {
-      const parsed = parseScope(scope);
-      const methodMatch = parsed.methods.includes("*") || parsed.methods.includes(upperMethod);
-      if (methodMatch && matchPath(parsed.pattern, path)) return true;
-    } else {
-      const methodMatch = scope.methods.some((m) => m === "*" || m.toUpperCase() === upperMethod);
-      if (!methodMatch) continue;
-      if (!matchPath(scope.pattern, path)) continue;
-
-      if (!scope.bodyFilters || scope.bodyFilters.length === 0) {
-        return true;
-      }
-
-      if (body === undefined) return false;
-
-      if (scope.bodyFilters.every((f) => matchBodyFilter(f, body))) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  return createPathMatcher(scopes, body)(method, path);
 }
 
 // --- ADR-0009 §3 et §4 : forme unique d'autorisation ---
@@ -230,13 +253,14 @@ export function checkRequestAccess(
     return { allowed: false, denialReason: "invalid_path", queryConstrained: false };
   }
 
-  const rawAllowed = checkAccess(scopes, method, rawPath, body);
-  if (!rawAllowed) {
+  const matchesPath = createPathMatcher(scopes, body);
+
+  if (!matchesPath(method, rawPath)) {
     return { allowed: false, denialReason: "path", queryConstrained: false };
   }
   // Le controle porte sur toutes les formes plausibles, l'emission sur la forme brute :
   // ajouter une forme ne peut que reduire l'ensemble autorise (ADR-0009 §3).
-  if (canonical !== rawPath && !checkAccess(scopes, method, canonical, body)) {
+  if (canonical !== rawPath && !matchesPath(method, canonical)) {
     return { allowed: false, denialReason: "path_encoded", queryConstrained: false };
   }
   return { allowed: true, queryConstrained: false };

--- a/tests/testu/middleware/scopes-body-eval.test.ts
+++ b/tests/testu/middleware/scopes-body-eval.test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "@std/assert";
+import { checkRequestAccess, type Scope } from "../../../src/middleware/scopes.ts";
+
+// Le corps expose ses champs par des accesseurs : une lecture vaut une evaluation de filtre.
+// C'est la seule facon d'observer le cout depuis l'exterieur sans instrumenter le code teste.
+function countingBody(values: Record<string, string>): { body: unknown; reads: () => number } {
+  let reads = 0;
+  const body: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    Object.defineProperty(body, key, {
+      enumerable: true,
+      get() {
+        reads++;
+        return value;
+      },
+    });
+  }
+  return { body, reads: () => reads };
+}
+
+function filtered(pattern: string, key: string, expected: string): Scope {
+  return {
+    methods: ["POST"],
+    pattern,
+    bodyFilters: [{ objectPath: key, objectValue: [{ type: "any", value: expected }] }],
+  };
+}
+
+Deno.test("T4: un scope autorise sur les deux formes n'evalue son corps qu'une fois", () => {
+  const { body, reads } = countingBody({ branch: "main" });
+
+  const v = checkRequestAccess([filtered("/v1/*", "branch", "main")], "POST", "/v1/./items", body);
+
+  assertEquals(v.allowed, true);
+  assertEquals(reads(), 1);
+});
+
+Deno.test("T4: un scope ecarte par son corps n'est pas reevalue a la seconde passe", () => {
+  const { body, reads } = countingBody({ branch: "dev" });
+  const scopes: Scope[] = [filtered("/v1/*", "branch", "main"), "POST:/v1/*"];
+
+  const v = checkRequestAccess(scopes, "POST", "/v1/./items", body);
+
+  assertEquals(v.allowed, true);
+  assertEquals(reads(), 1);
+});
+
+Deno.test("T4: le budget est d'une evaluation par scope, pas d'une par passe", () => {
+  const { body, reads } = countingBody({ a: "1", b: "2" });
+  const scopes: Scope[] = [filtered("/v1/*", "a", "autre"), filtered("/v1/*", "b", "2")];
+
+  const v = checkRequestAccess(scopes, "POST", "/v1/./items", body);
+
+  assertEquals(v.allowed, true);
+  assertEquals(reads(), 2);
+});
+
+Deno.test("T4: le refus par filtre de corps reste un refus, cause inchangee", () => {
+  const { body, reads } = countingBody({ branch: "dev" });
+
+  const v = checkRequestAccess([filtered("/v1/*", "branch", "main")], "POST", "/v1/./items", body);
+
+  assertEquals(v.allowed, false);
+  assertEquals(v.denialReason, "path");
+  assertEquals(reads(), 1);
+});
+
+Deno.test("T4: un scope filtre autorise en forme brute reste refuse sur la forme canonique", () => {
+  const { body, reads } = countingBody({ branch: "main" });
+
+  const v = checkRequestAccess(
+    [filtered("/v1/public/*", "branch", "main")],
+    "POST",
+    "/v1/public/..%2f..%2fadmin",
+    body,
+  );
+
+  assertEquals(v.allowed, false);
+  assertEquals(v.denialReason, "path_encoded");
+  assertEquals(reads(), 1);
+});
+
+Deno.test("T4: un scope filtre sans corps refuse immediatement, forme brute non canonique", () => {
+  const v = checkRequestAccess([filtered("/v1/*", "branch", "main")], "POST", "/v1/./items");
+
+  assertEquals(v.allowed, false);
+  assertEquals(v.denialReason, "path");
+});


### PR DESCRIPTION
## Le défaut

`checkRequestAccess` contrôle le chemin sur sa forme brute et sur sa forme canonique, garantie de l'ADR-0009 section 3. Les body filters vivant à l'intérieur de `checkAccess`, ils étaient évalués une fois par passe.

C'est l'appelant qui décide quand la seconde passe se déclenche : il lui suffit d'envoyer `//v1/items` ou `/v1/./items`. Le budget de 256 `ObjectValue` par blob de l'ADR-0010 valait donc en réalité 512 évaluations, et le budget de 4 valeurs `regex` en valait 8. Les mesures qui ont calibré ces plafonds portaient sur une seule passe.

## Le correctif

La décision de corps est calculée une fois par scope et mémoïsée dans une closure locale, interrogée par les deux passes. Elle ne dépend pas de la forme du chemin, donc le verdict est identique dans tous les cas. `checkAccess` garde sa signature publique, une centaine de tests l'appellent directement.

Ce qui n'a **pas** été fait, délibérément : fusionner les deux passes en une boucle unique où un scope devrait autoriser les deux formes. Ce n'est pas équivalent, deux scopes distincts peuvent couvrir chacun une forme, et la fusion aurait changé le périmètre autorisé au lieu de son coût.

La pureté est préservée : mémo local à la closure, aucun état global, aucun compteur traversant. La fonction est bundlée côté navigateur autant que côté serveur.

## Le test

Il compte les évaluations par des accesseurs sur le corps, chaque lecture de champ incrémentant un compteur. C'est le seul moyen d'observer le coût de l'extérieur sans instrumenter le code testé. Vérifié discriminant en retirant le correctif : trois cas passent de 1 à 2 évaluations et de 2 à 4. Les cas qui portent sur le verdict passaient déjà avant, ce qui confirme qu'un test de verdict seul n'aurait rien attrapé.

La table de l'ADR-0009 section 3 vit déjà dans `scopes-path-encoding.test.ts` et passe inchangée. Ce qu'elle ne couvrait pas et qui est ajouté : un scope **avec** body filters autorisé sur la forme brute et refusé sur la canonique doit toujours sortir en `path_encoded`.

## Trouvé en passant, non corrigé ici

`checkRequestAccess` n'émet que trois `denialReason` : `invalid_path`, `path` et `path_encoded`. Les valeurs `method`, `body` et `query` existent dans l'union du type sans qu'aucune ligne de code ne les produise, donc un refus par body filter remonte aujourd'hui en `path`. Ce trou est antérieur à cette PR et n'est pas aggravé par elle. Il sera traité par la feature `queryFilters`, qui doit de toute façon émettre un diagnostic par paramètre.

## Vérification

`deno task verify` vert, 656 tests, 0 échec.

Défaut trouvé par le testeur pendant le challenge de `queryFilters`, point T4 de `docs/review/challenge-query-filters-v5.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request access checks to evaluate body-based rules only once per scope, including when both raw and canonical paths are checked.
  * Preserved existing allow, skip, and deny behavior while ensuring requests without required bodies are denied immediately.

* **Tests**
  * Added coverage for body-filter evaluation counts, rejection behavior, path handling, and missing request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->