### PR TITLE
fix(openapi): declare le 413 payload_too_large sur les routes qui le produisent

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -112,6 +112,17 @@ const ListAddonsError502Schema = errorSchema(
 
 const TestProxyError400Schema = errorSchema(["invalid_body"], "TestProxyError400");
 
+// Le 413 n'est produit par aucun handler mais par le bodyLimit monte sur /api/* dans
+// src/main.ts : createRoute ne voit que le handler, la reponse doit donc etre declaree a la
+// main sur chaque route plafonnee. Schema partage, le code est le meme pour toutes puisqu'il
+// sort du meme middleware.
+const PayloadTooLargeErrorSchema = errorSchema(["payload_too_large"], "PayloadTooLargeError");
+
+const payloadTooLargeResponse = {
+  description: "Request body exceeds the body size cap of this route",
+  content: { "application/json": { schema: PayloadTooLargeErrorSchema } },
+};
+
 const ObjectValueSchema = z.union([
   z.object({ type: z.literal("any"), value: z.unknown() }),
   z.object({ type: z.literal("wildcard") }),
@@ -394,6 +405,7 @@ const decodeRoute = createRoute({
       description: "Unable to decrypt blob (wrong key or corrupted blob)",
       content: { "application/json": { schema: DecodeError401Schema } },
     },
+    413: payloadTooLargeResponse,
     500: {
       description: "Server misconfigured (FGP_SALT missing)",
       content: { "application/json": { schema: DecodeError500Schema } },
@@ -423,6 +435,7 @@ const shareEncodeRoute = createRoute({
       description: "Invalid body (missing or malformed fields)",
       content: { "application/json": { schema: ShareEncodeError400Schema } },
     },
+    413: payloadTooLargeResponse,
   },
 });
 
@@ -447,6 +460,7 @@ const shareDecodeRoute = createRoute({
       description: "Invalid body or unable to decode the shared config string",
       content: { "application/json": { schema: ShareDecodeError400Schema } },
     },
+    413: payloadTooLargeResponse,
   },
 });
 
@@ -487,6 +501,7 @@ const generateRoute = createRoute({
         "Invalid body, generated blob exceeds 4KB, or scope limits violated (body filters, depth, etc.)",
       content: { "application/json": { schema: GenerateError400Schema } },
     },
+    413: payloadTooLargeResponse,
     500: {
       description: "Server misconfigured (FGP_SALT missing)",
       content: { "application/json": { schema: GenerateError500Schema } },
@@ -519,6 +534,7 @@ const listAppsRoute = createRoute({
       description: "Scalingo token exchange failed (token invalid or unauthorized)",
       content: { "application/json": { schema: ListAppsError401Schema } },
     },
+    413: payloadTooLargeResponse,
     502: {
       description:
         "Scalingo API unreachable (fetch throw) or returned a non-ok status when listing apps",
@@ -557,6 +573,7 @@ const listAddonsRoute = createRoute({
       description: "The application does not exist on this Scalingo account",
       content: { "application/json": { schema: ListAddonsError404Schema } },
     },
+    413: payloadTooLargeResponse,
     502: {
       description:
         "Scalingo API unreachable (fetch throw) or returned a non-ok status when listing addons",
@@ -587,6 +604,7 @@ const testProxyRoute = createRoute({
       description: "Invalid body (missing or malformed fields)",
       content: { "application/json": { schema: TestProxyError400Schema } },
     },
+    413: payloadTooLargeResponse,
   },
 });
 

--- a/tests/testi/openapi-body-limit.test.ts
+++ b/tests/testi/openapi-body-limit.test.ts
@@ -1,0 +1,156 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+
+import { app } from "../../src/main.ts";
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"];
+
+// Trois fois le plus haut plafond monte dans src/main.ts. Un plafond releve au-dela de cette
+// taille ferait echouer la sonde et le test crierait a la sur-declaration : la marge se releve
+// en meme temps que le plafond.
+const OVERSIZED_BODY = JSON.stringify({ padding: "a".repeat(200 * 1024) });
+
+type ErrorSchema = { $ref?: string; properties?: { error?: { enum?: string[] } } };
+
+type Operation = {
+  requestBody?: unknown;
+  responses: Record<string, { content?: Record<string, { schema?: ErrorSchema }> }>;
+};
+
+type Spec = {
+  paths: Record<string, Record<string, Operation>>;
+  components: { schemas: Record<string, ErrorSchema> };
+};
+
+const originalFetch = globalThis.fetch;
+
+function setup() {
+  Deno.env.set("FGP_SALT", "openapi-body-limit-test-salt");
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  Deno.env.set("SCALINGO_AUTH_URL", "https://auth.mock.local");
+  // Une parite cassee laisse la requete atteindre le handler : sans ce garde-fou, la sonde
+  // partirait reellement sur le reseau au lieu d'echouer proprement sur l'assertion.
+  globalThis.fetch = (): Promise<Response> => Promise.resolve(new Response("{}", { status: 200 }));
+}
+
+function teardown() {
+  globalThis.fetch = originalFetch;
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+  Deno.env.delete("SCALINGO_AUTH_URL");
+}
+
+async function loadSpec(): Promise<Spec> {
+  const res = await app.request("/api/openapi.json");
+  return await res.json() as Spec;
+}
+
+function operationsOf(spec: Spec): { path: string; method: string; operation: Operation }[] {
+  const out: { path: string; method: string; operation: Operation }[] = [];
+  for (const [path, item] of Object.entries(spec.paths)) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (HTTP_METHODS.includes(method)) out.push({ path, method, operation });
+    }
+  }
+  return out;
+}
+
+function declaredErrorCodes(spec: Spec, operation: Operation, status: string): string[] {
+  const schema = operation.responses[status]?.content?.["application/json"]?.schema;
+  if (!schema) return [];
+  const resolved = schema.$ref
+    ? spec.components.schemas[schema.$ref.replace("#/components/schemas/", "")]
+    : schema;
+  return resolved?.properties?.error?.enum ?? [];
+}
+
+async function servesPayloadTooLarge(path: string, method: string): Promise<boolean> {
+  const res = await app.request(path, {
+    method: method.toUpperCase(),
+    headers: { "Content-Type": "application/json" },
+    body: OVERSIZED_BODY,
+  });
+  const raw = await res.text();
+  if (res.status !== 413) return false;
+  try {
+    return (JSON.parse(raw) as { error?: string }).error === "payload_too_large";
+  } catch {
+    return false;
+  }
+}
+
+Deno.test({
+  name:
+    "AC-47.4: PARITE, une operation OpenAPI declare 413 payload_too_large si et seulement si elle le sert",
+  fn: async () => {
+    setup();
+    try {
+      const spec = await loadSpec();
+      const operations = operationsOf(spec);
+      assertNotEquals(operations.length, 0, "aucune operation enumeree, le test ne verifie rien");
+
+      const undeclared: string[] = [];
+      const overdeclared: string[] = [];
+      let probed = 0;
+
+      for (const { path, method, operation } of operations) {
+        const declares = declaredErrorCodes(spec, operation, "413").includes("payload_too_large");
+
+        // Une operation sans corps documente ne peut pas depasser un plafond de corps : Deno
+        // n'expose aucun body sur un GET, bodyLimit passe la main et la route repond 200.
+        // La declarer en 413 documenterait une reponse que rien ne peut atteindre.
+        if (!operation.requestBody) {
+          if (declares) overdeclared.push(`${method.toUpperCase()} ${path} (sans corps)`);
+          continue;
+        }
+
+        probed++;
+        const serves = await servesPayloadTooLarge(path, method);
+        if (serves && !declares) undeclared.push(`${method.toUpperCase()} ${path}`);
+        if (!serves && declares) overdeclared.push(`${method.toUpperCase()} ${path}`);
+      }
+
+      assertNotEquals(probed, 0, "aucune operation sondee, le test ne verifie rien");
+
+      assertEquals(
+        undeclared,
+        [],
+        `413 payload_too_large servi mais absent de l'enum OpenAPI : ${undeclared.join(", ")}`,
+      );
+      assertEquals(
+        overdeclared,
+        [],
+        `413 payload_too_large declare mais jamais servi : ${overdeclared.join(", ")}`,
+      );
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-47.5: INVARIANT structurel, le plafond de corps n'est monte que sous /api/",
+  fn: () => {
+    // Monte sur un pattern fourre-tout, le plafond couvrirait la route proxy : le corps
+    // transmis en flux passerait en tampon et les uploads volumineux legitimes casseraient
+    // (ADR-0010 D6). La source de verite est le montage reel, pas une liste ecrite ici.
+    const mounts = app.routes.filter((route) => route.handler.name.startsWith("bodyLimit"));
+
+    assertNotEquals(
+      mounts.length,
+      0,
+      "aucun montage de plafond reconnu sur l'app, le test ne verifie plus rien",
+    );
+
+    for (const mount of mounts) {
+      assertEquals(
+        mount.path.startsWith("/api/"),
+        true,
+        `plafond de corps monte hors /api/ sur ${mount.path}`,
+      );
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
## Le défaut

`apiBodyLimit` renvoie un `413 payload_too_large` sur les chemins `/api/*`, et aucune route ne le déclarait. `createRoute` de `@hono/zod-openapi` ne voit que ce que déclare le handler, pas ce que produit un middleware monté au-dessus. Le contrat publié mentait donc par omission sur sept endpoints, et un client généré depuis la spec ne sait pas que ce statut existe.

## Quelles routes exactement

Sept opérations sur huit sont plafonnées. Le dernier `app.use("/api/*", apiBodyLimit(64 * 1024))` est un attrape-tout qui couvre aussi `/api/share/encode`, absent de la liste explicite.

`GET /api/salt` ne l'est pas, et ce n'est pas un jugement : vérifié en envoyant un `GET /api/salt` avec 200 Ko de corps sur une socket TCP brute vers un `Deno.serve` réel. Réponse 200. Deno n'expose aucun body sur un GET, `bodyLimit` passe la main immédiatement. Lui déclarer un 413 aurait été le mensonge de contrat symétrique de celui qu'on corrige.

## Le test

Il dérive la parité du comportement réel et n'écrit aucune liste à la main, sinon il se périmerait exactement comme les enums viennent de le faire. Il lit la spec servie par `/api/openapi.json`, énumère les opérations, envoie un corps surdimensionné sur chacune de celles qui déclarent un `requestBody`, résout le `$ref` de la réponse 413 jusqu'à l'enum et compare. Il échoue dans les deux sens, servi mais non déclaré et déclaré mais non servi, avec deux garde-fous anti-test-vide.

Un second test vérifie que le plafond ne sort jamais de `/api/`, sur le modèle du recensement de routes déjà utilisé pour les en-têtes de sécurité. Un montage sur `*` mettrait en tampon le corps de la route proxy, transmis en flux, ce que l'ADR-0010 interdit.

Les tests ont été vérifiés discriminants par mutation : retirer le 413 de `/api/test-proxy`, l'ajouter à `/api/salt`, déplacer le plafond sur `*`. Les trois sont attrapées.

## Suites documentaires, à traiter par le PO au merge

La convention qui dit qu'un code produit par un middleware monté compte comme un code de la route se termine dans `CLAUDE.md` par « le 413 `payload_too_large` d'`apiBodyLimit` manque aujourd'hui dans les enums de tous les `/api/*` ». Cette phrase devient fausse avec cette PR.

`/llms.txt` décrit le 413 comme le plafond de 512 Ko du proxy, ce qui est exact puisque la liste est celle de la route proxy, mais les plafonds `/api/*` n'y apparaissent nulle part.

Le contrat OpenAPI publié change pour sept endpoints, c'est visible par les consommateurs de l'API et ça mérite une entrée de changelog.

## Vérification

`deno task verify` vert, 652 tests, 0 échec.