### PR TITLE
fix(proxy): ne relaie plus les en-tetes de codage d'un corps deja decode

### DIFF
--- a/src/middleware/proxy.ts
+++ b/src/middleware/proxy.ts
@@ -148,7 +148,7 @@ async function forwardRequest(
   config: BlobConfig,
   proxyPath: string,
   authHeaders: Headers,
-): Promise<Response> {
+): Promise<{ response: Response; decodingDisabled: boolean }> {
   const url = new URL(c.req.url);
   const parsed = parseTargetUrl(config.target);
   if ("error" in parsed) throw new Error("Invalid target");
@@ -174,12 +174,56 @@ async function forwardRequest(
     init.body = c.req.raw.body;
   }
 
-  return await egressFetch(targetUrl, init);
+  // Se lit sur les en-tetes reellement partis, apres toutes les passes : un Range comme
+  // un Accept-Encoding peut venir de l'appelant comme d'un AuthSpec.
+  const decodingDisabled = runtimeDecodingDisabled(headers);
+
+  return { response: await egressFetch(targetUrl, init), decodingDisabled };
 }
 
-function handleUpstreamResponse(response: Response): Response {
+// Mesure sur Deno 2.9.5 : deflate, zstd et tout encodage inconnu ressortent bruts.
+const RUNTIME_DECODED_ENCODINGS = new Set(["gzip", "br"]);
+
+// Deux en-tetes de la requete sortante suffisent a desactiver le decodage automatique du
+// runtime, auquel cas le corps revient compresse. Mesure sur Deno 2.9.5 : un Range, quelle
+// que soit sa valeur et meme si la reponse finit en 200, parce que la reponse peut etre un
+// fragment indecodable ; et un Accept-Encoding valant exactement identity, "identity, gzip"
+// ou "identity;q=0" laissant au contraire le decodage actif.
+function runtimeDecodingDisabled(sentHeaders: Headers): boolean {
+  if (sentHeaders.has("Range")) return true;
+  return (sentHeaders.get("Accept-Encoding") ?? "").trim().toLowerCase() === "identity";
+}
+
+function runtimeDecodedBody(response: Response, decodingDisabled: boolean): boolean {
+  // Sans corps (HEAD, 304) rien n'a ete decode, et le Content-Length amont decrit alors
+  // l'entite, pas ce qu'on transmet : il doit survivre.
+  if (response.body === null || decodingDisabled) return false;
+  const encoding = response.headers.get("Content-Encoding");
+  return encoding !== null && RUNTIME_DECODED_ENCODINGS.has(encoding.trim().toLowerCase());
+}
+
+function handleUpstreamResponse(response: Response, decodingDisabled: boolean): Response {
   const headers = new Headers(response.headers);
   headers.delete("Set-Cookie");
+
+  // Hop-by-hop (RFC 9110 §7.6.1) : decrit le framing du hop amont, pas celui qu'on emet,
+  // et le serveur choisit le sien. Symetrique du strip deja fait sur la requete.
+  headers.delete("Transfer-Encoding");
+
+  // Deviation assumee a la transparence de l'ADR-0006, imposee par le runtime et non par
+  // un choix produit : fetch a deja decode le corps a la reception, mais expose encore
+  // les en-tetes amont qui le decrivaient compresse. Les relayer fait echouer tout client
+  // qui les respecte (undici tente un gunzip sur du clair puis coupe sur "terminated"),
+  // et le Content-Length perime tronque la reponse a la premiere lecture. Garder ces
+  // en-tetes reviendrait a mentir sur ce qu'on envoie.
+  // Le decodage n'etant ni universel ni garanti, la suppression est conditionnelle :
+  // hors des cas couverts par runtimeDecodedBody, le corps ressort bel et bien compresse
+  // et les en-tetes amont sont exacts, les supprimer casserait le client dans l'autre sens.
+  if (runtimeDecodedBody(response, decodingDisabled)) {
+    headers.delete("Content-Encoding");
+    headers.delete("Content-Length");
+  }
+
   headers.set(FGP_SOURCE_HEADER, FGP_SOURCE_UPSTREAM);
 
   return new Response(response.body, {
@@ -380,9 +424,9 @@ async function handleProxy(c: Context, blobRaw: string, proxyPath: string): Prom
     );
   }
 
-  let response;
+  let forwardResult;
   try {
-    response = await forwardRequest(c, config, proxyPath, authHeaders);
+    forwardResult = await forwardRequest(c, config, proxyPath, authHeaders);
   } catch {
     return await finishWithCapture(
       c,
@@ -398,7 +442,10 @@ async function handleProxy(c: Context, blobRaw: string, proxyPath: string): Prom
     );
   }
 
-  const forwarded = handleUpstreamResponse(response);
+  const forwarded = handleUpstreamResponse(
+    forwardResult.response,
+    forwardResult.decodingDisabled,
+  );
   return await finishWithCapture(
     c,
     config,

--- a/tests/testi/proxy-content-encoding.test.ts
+++ b/tests/testi/proxy-content-encoding.test.ts
@@ -1,0 +1,322 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+
+// Le runtime decode gzip et br a la reception du fetch. Les en-tetes amont qui
+// decrivaient le corps compresse deviennent alors faux et doivent partir, mais
+// uniquement dans ce cas : hors decodage ils restent exacts et doivent survivre.
+
+const CLIENT_KEY = "content-encoding-test-key-pad";
+const SERVER_SALT = "content-encoding-test-salt";
+
+const originalFetch = globalThis.fetch;
+
+function setup(): void {
+  _resetStoreForTests();
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+}
+
+function teardown(): void {
+  globalThis.fetch = originalFetch;
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+}
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+async function makeBlob(scopes: string[]): Promise<string> {
+  return await encryptBlob(
+    {
+      v: 2,
+      token: "tk-us-test-token",
+      target: "https://api.mock.local",
+      auth: "bearer",
+      scopes,
+      ttl: 3600,
+      createdAt: Math.floor(Date.now() / 1000),
+    },
+    CLIENT_KEY,
+    SERVER_SALT,
+  );
+}
+
+function mockUpstream(body: BodyInit | null, headers: HeadersInit, status = 200): void {
+  globalThis.fetch =
+    (() => Promise.resolve(new Response(body, { status, headers }))) as typeof globalThis.fetch;
+}
+
+function mockUpstreamCapturing(
+  build: () => Response,
+  seen: { acceptEncoding: string | null },
+): void {
+  globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => {
+    seen.acceptEncoding = new Headers(init?.headers).get("Accept-Encoding");
+    return Promise.resolve(build());
+  }) as typeof globalThis.fetch;
+}
+
+Deno.test({
+  name: "decoded gzip body no longer advertises Content-Encoding nor Content-Length",
+  fn: async () => {
+    setup();
+    const payload = JSON.stringify({ apps: ["a", "b"] });
+    mockUpstream(payload, {
+      "Content-Type": "application/json",
+      "Content-Encoding": "gzip",
+      "Content-Length": "52",
+    });
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("Content-Encoding"), null);
+    assertEquals(res.headers.get("Content-Length"), null);
+    assertEquals(res.headers.get("X-FGP-Source"), "upstream");
+    assertEquals(await res.text(), payload);
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "decoded br body no longer advertises Content-Encoding",
+  fn: async () => {
+    setup();
+    mockUpstream(JSON.stringify({ ok: true }), {
+      "Content-Type": "application/json",
+      "Content-Encoding": "br",
+    });
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+
+    assertEquals(res.headers.get("Content-Encoding"), null);
+    await res.body?.cancel();
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "stripping stays a denylist, every other upstream header still passes",
+  fn: async () => {
+    setup();
+    mockUpstream(JSON.stringify({ ok: true }), {
+      "Content-Type": "application/json",
+      "Content-Encoding": "gzip",
+      "Content-Length": "52",
+      "ETag": '"v1-abc"',
+      "Cache-Control": "public, max-age=60",
+      "X-RateLimit-Remaining": "42",
+      "X-Scalingo-Request-Id": "req-9f2",
+      "Vary": "Accept-Encoding",
+      "Link": '<https://api.mock.local/v1/apps?page=2>; rel="next"',
+    });
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+
+    assertEquals(res.headers.get("Content-Type"), "application/json");
+    assertEquals(res.headers.get("ETag"), '"v1-abc"');
+    assertEquals(res.headers.get("Cache-Control"), "public, max-age=60");
+    assertEquals(res.headers.get("X-RateLimit-Remaining"), "42");
+    assertEquals(res.headers.get("X-Scalingo-Request-Id"), "req-9f2");
+    assertEquals(res.headers.get("Vary"), "Accept-Encoding");
+    assertEquals(
+      res.headers.get("Link"),
+      '<https://api.mock.local/v1/apps?page=2>; rel="next"',
+    );
+    await res.body?.cancel();
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "encoding the runtime does not decode keeps its headers untouched",
+  fn: async () => {
+    setup();
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    for (const encoding of ["deflate", "zstd", "compress", "x-vendor-enc", "gzip, br"]) {
+      mockUpstream("still-encoded-bytes", {
+        "Content-Type": "application/octet-stream",
+        "Content-Encoding": encoding,
+      });
+      const res = await app.request(`/${blob}/v1/apps`, {
+        headers: { "X-FGP-Key": CLIENT_KEY },
+      });
+      assertEquals(res.headers.get("Content-Encoding"), encoding);
+      await res.body?.cancel();
+    }
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "caller asking identity gets the still-compressed body with its headers intact",
+  fn: async () => {
+    setup();
+    const seen = { acceptEncoding: null as string | null };
+    mockUpstreamCapturing(
+      () =>
+        new Response("gzipped-bytes-here", {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            "Content-Length": "18",
+          },
+        }),
+      seen,
+    );
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      headers: { "X-FGP-Key": CLIENT_KEY, "Accept-Encoding": "identity" },
+    });
+
+    assertEquals(seen.acceptEncoding, "identity");
+    assertEquals(res.headers.get("Content-Encoding"), "gzip");
+    assertEquals(res.headers.get("Content-Length"), "18");
+    await res.body?.cancel();
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "identity combined with another codec does not disable runtime decoding",
+  fn: async () => {
+    setup();
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    for (const accept of ["identity, gzip", "identity;q=0", "gzip", "*"]) {
+      const seen = { acceptEncoding: null as string | null };
+      mockUpstreamCapturing(
+        () =>
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json", "Content-Encoding": "gzip" },
+          }),
+        seen,
+      );
+      const res = await app.request(`/${blob}/v1/apps`, {
+        headers: { "X-FGP-Key": CLIENT_KEY, "Accept-Encoding": accept },
+      });
+      assertEquals(seen.acceptEncoding, accept);
+      assertEquals(res.headers.get("Content-Encoding"), null);
+      await res.body?.cancel();
+    }
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "a Range request disables runtime decoding, so encoding headers must survive",
+  fn: async () => {
+    setup();
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    // La valeur du Range est sans importance et le status non plus : la seule presence de
+    // l'en-tete sur la requete sortante suffit a desactiver le decodage du runtime.
+    for (const range of ["bytes=0-100", "bytes=0-", "invalid-range-value"]) {
+      for (const status of [200, 206]) {
+        mockUpstream("still-gzipped-bytes", {
+          "Content-Type": "application/json",
+          "Content-Encoding": "gzip",
+          "Content-Length": "52",
+        }, status);
+        const res = await app.request(`/${blob}/v1/apps`, {
+          headers: { "X-FGP-Key": CLIENT_KEY, "Range": range },
+        });
+        assertEquals(res.status, status);
+        assertEquals(res.headers.get("Content-Encoding"), "gzip");
+        assertEquals(res.headers.get("Content-Length"), "52");
+        await res.body?.cancel();
+      }
+    }
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "hop-by-hop Transfer-Encoding is never relayed downstream",
+  fn: async () => {
+    setup();
+    mockUpstream(JSON.stringify({ ok: true }), {
+      "Content-Type": "application/json",
+      "Transfer-Encoding": "chunked",
+    });
+    const app = createApp();
+    const blob = await makeBlob(["*:*"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+
+    assertEquals(res.headers.get("Transfer-Encoding"), null);
+    assertEquals(res.headers.get("X-FGP-Source"), "upstream");
+    await res.body?.cancel();
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "bodyless response keeps the upstream entity headers",
+  fn: async () => {
+    setup();
+    mockUpstream(null, {
+      "Content-Type": "application/json",
+      "Content-Encoding": "gzip",
+      "Content-Length": "4707",
+    });
+    const app = createApp();
+    const blob = await makeBlob(["HEAD:/v1/apps"]);
+
+    const res = await app.request(`/${blob}/v1/apps`, {
+      method: "HEAD",
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+
+    assertEquals(res.headers.get("Content-Encoding"), "gzip");
+    assertEquals(res.headers.get("Content-Length"), "4707");
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Bug de production. Un client conforme qui passe par le proxy sur une API cible qui compresse ses réponses reçoit une réponse illisible.

## Le défaut

`handleUpstreamResponse` recopiait `Content-Encoding` et `Content-Length` de la réponse amont. Le runtime ayant déjà décodé le corps au moment du `fetch`, le proxy annonçait `gzip` sur du clair, avec une longueur qui décrivait le compressé.

Un client qui respecte ces en-têtes échoue : undici tente un gunzip sur du clair puis coupe sur `terminated`. `curl` ne le voit pas, il ne décompresse que si on lui passe `--compressed`.

Le bug est plus grave que le symptôme rapporté quand l'amont répond en `Content-Length` plutôt qu'en chunked : sur 59 Ko mesurés, le proxy servait **4096 octets** puis coupait, corps irrécupérable.

## Pourquoi la suppression est conditionnelle

Le correctif naïf, supprimer les deux en-têtes sans condition, cassait trois cas réels, dont un au moment même du déploiement.

Le décodage automatique du runtime n'est ni universel ni inconditionnel. Mesuré sur Deno 2.9.5 avec un serveur TCP brut pour contrôler les octets exacts : seuls `gzip` et `br` sont décodés, `deflate`, `zstd` et tout encodage inconnu ressortent bruts avec leurs en-têtes exacts. Et deux en-têtes de la requête sortante désactivent le décodage, un `Range` quelle que soit sa valeur, et un `Accept-Encoding` valant **exactement** `identity` (`identity, gzip` et `identity;q=0` laissent au contraire le décodage actif).

Le contournement `Accept-Encoding: identity` actuellement en place chez l'appelant tombe précisément dans ce cas : il reçoit un corps réellement compressé, et le correctif inconditionnel lui aurait retiré l'en-tête qui le dit, le cassant avant qu'il ait pu retirer son contournement.

## Transfer-Encoding

Ajouté sur un autre fondement, sans bug observé et je l'assume comme tel : c'est un hop-by-hop de la RFC 9110 section 7.6.1 qui décrit le framing du hop amont et pas celui qu'on émet, `DENIED_HEADERS` le traite déjà comme tel côté requête, et le relayer est interdit en HTTP/2, ce que sert Deno Deploy.

## Doctrine

C'est une déviation assumée à la transparence de l'ADR-0006, imposée par le runtime et non par un choix produit. Garder ces en-têtes reviendrait à mentir sur ce qu'on envoie. Le commentaire au point de suppression l'explique, pour qu'un futur lecteur ne la « nettoie » pas.

Les passages de documentation qui affirment que `Set-Cookie` est le seul en-tête strippé deviennent faux : `CLAUDE.md`, `docs/specs.md`, l'ADR-0006, l'ADR-0009, plus la copy de `/llms.txt` et du panneau Doc. Ils sont recensés et partent au PO dans la foulée, avec l'entrée de changelog.

## Tests

Neuf tests dans un fichier dédié : le cas gzip, le cas br, la non-régression inverse sur sept en-têtes amont variés pour empêcher toute dérive vers une allowlist, les encodages non décodés, `identity`, `identity, gzip`, `Range`, `Transfer-Encoding`, et le cas sans corps où le `Content-Length` amont décrit l'entité et doit survivre.

Vérifiés discriminants par mutation. Et validé sur du vrai réseau avec un client `fetch` conforme : le cas de production ressort en 42090 octets de JSON valide sans en-tête menteur, le contournement `identity` et le cas `Range` ressortent compressés avec leurs en-têtes intacts.

`deno task verify` vert, 667 tests, 0 échec.