### PR TITLE
test(securite): couvre les quatre garanties de l'ADR-0009 qu'aucun test ne protegeait

### DIFF
--- a/tests/testi/proxy-headers-policy.test.ts
+++ b/tests/testi/proxy-headers-policy.test.ts
@@ -104,6 +104,50 @@ Deno.test({
   sanitizeResources: false,
 });
 
+// Registre v5 AC-45.4. Le test ci-dessous porte deja ce numero pour un autre enonce,
+// decalage recense dans docs/review/ac-coverage-v5.md et traite hors de ce lot.
+Deno.test({
+  name: "AC-45.4 (registre v5): les en-tetes nommes par Connection sont retires aussi",
+  fn: async () => {
+    setup();
+    const h = await call({
+      "Connection": "X-Custom-A, X-Custom-B",
+      "X-Custom-A": "valeur-a",
+      "X-Custom-B": "valeur-b",
+      "X-Custom-C": "valeur-c",
+    });
+
+    assertEquals(h.get("connection"), null);
+    assertEquals(h.get("x-custom-a"), null, "en-tete nomme par Connection relaye");
+    assertEquals(h.get("x-custom-b"), null, "en-tete nomme par Connection relaye");
+
+    // Controle negatif : la regle porte sur ce que Connection designe, pas sur tout
+    // en-tete proprietaire. Sans lui, un strip trop large passerait pour une reussite.
+    assertEquals(h.get("x-custom-c"), "valeur-c");
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-45.4 bis (registre v5): la designation par Connection ignore casse et espaces",
+  fn: async () => {
+    setup();
+    const h = await call({
+      "Connection": "  x-custom-a ,X-CUSTOM-B  ",
+      "X-Custom-A": "valeur-a",
+      "X-Custom-B": "valeur-b",
+    });
+
+    assertEquals(h.get("x-custom-a"), null);
+    assertEquals(h.get("x-custom-b"), null);
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
 Deno.test({
   name: "AC-45.4: les en-tetes de provenance ne sont pas transmis",
   fn: async () => {

--- a/tests/testi/proxy-path-emission.test.ts
+++ b/tests/testi/proxy-path-emission.test.ts
@@ -1,0 +1,166 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { blobHeaderProxy, proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+
+const CLIENT_KEY = "path-emission-test-key-012345";
+const SERVER_SALT = "path-emission-salt";
+const TARGET = "https://api.mock.local";
+
+const originalFetch = globalThis.fetch;
+let emitted: string | null = null;
+
+function setup() {
+  _resetStoreForTests();
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  emitted = null;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    emitted = input instanceof Request ? input.url : String(input);
+    return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  }) as typeof globalThis.fetch;
+}
+
+function teardown() {
+  globalThis.fetch = originalFetch;
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+}
+
+async function makeBlob(target = TARGET, scopes: string[] = ["*:*"]): Promise<string> {
+  return await encryptBlob(
+    {
+      v: 2,
+      token: "tok",
+      target,
+      auth: "bearer",
+      scopes,
+      ttl: 3600,
+      createdAt: Math.floor(Date.now() / 1000),
+    },
+    CLIENT_KEY,
+    SERVER_SALT,
+  );
+}
+
+function urlModeApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+function headerModeApp(): Hono {
+  const app = new Hono();
+  app.use("*", blobHeaderProxy());
+  return app;
+}
+
+/** Cas GitLab : l'identifiant de projet porte un %2F qui appartient a la donnee. */
+const GITLAB_PATH = "/api/v4/projects/groupe%2Fprojet/repository/branches";
+
+Deno.test({
+  name: "AC-44.9: mode URL, le chemin percent-encode est emis tel que presente",
+  fn: async () => {
+    setup();
+    try {
+      const blob = await makeBlob();
+      const res = await urlModeApp().request(`/${blob}${GITLAB_PATH}`, {
+        headers: { "X-FGP-Key": CLIENT_KEY },
+      });
+      await res.body?.cancel();
+
+      assertEquals(res.status, 200);
+      assertEquals(emitted, `${TARGET}${GITLAB_PATH}`);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-44.9 bis: mode header, le chemin percent-encode est emis tel que presente",
+  fn: async () => {
+    setup();
+    try {
+      const blob = await makeBlob();
+      const res = await headerModeApp().request(GITLAB_PATH, {
+        headers: { "X-FGP-Key": CLIENT_KEY, "X-FGP-Blob": blob },
+      });
+      await res.body?.cancel();
+
+      assertEquals(res.status, 200);
+      assertEquals(emitted, `${TARGET}${GITLAB_PATH}`);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-44.9 ter: ni la casse de l'encodage ni les formes non canoniques ne bougent",
+  fn: async () => {
+    setup();
+    try {
+      // %2f minuscule, %2E qui decode en point, et un espace encode : trois formes qu'une
+      // normalisation reecrirait sans changer le sens du chemin pour un client naif, et
+      // dont la reecriture change bel et bien la ressource visee pour l'upstream.
+      const path = "/v1/files/a%2fb/c%2Ed/nom%20avec%20espace";
+      const blob = await makeBlob();
+      const res = await urlModeApp().request(`/${blob}${path}`, {
+        headers: { "X-FGP-Key": CLIENT_KEY },
+      });
+      await res.body?.cancel();
+
+      assertEquals(res.status, 200);
+      assertEquals(emitted, `${TARGET}${path}`);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-44.9 quater: la cible recoit le chemin octet pour octet",
+  fn: async () => {
+    _resetStoreForTests();
+    Deno.env.set("FGP_SALT", SERVER_SALT);
+    Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+
+    let received: string | null = null;
+    const server = Deno.serve(
+      { port: 0, onListen: () => {} },
+      (req) => {
+        received = new URL(req.url).pathname;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    );
+
+    try {
+      // Aucun stub de fetch ici : la garantie porte sur ce que la cible recoit, pas
+      // seulement sur ce que le proxy passe a fetch.
+      const target = `http://127.0.0.1:${server.addr.port}`;
+      const blob = await makeBlob(target);
+      const res = await urlModeApp().request(`/${blob}${GITLAB_PATH}`, {
+        headers: { "X-FGP-Key": CLIENT_KEY },
+      });
+      await res.body?.cancel();
+
+      assertEquals(res.status, 200);
+      assertEquals(received, GITLAB_PATH);
+    } finally {
+      await server.shutdown();
+      Deno.env.delete("FGP_SALT");
+      Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/scalingo-addon.test.ts
+++ b/tests/testi/scalingo-addon.test.ts
@@ -11,6 +11,7 @@ const SERVER_SALT = "scalingo-addon-test-salt";
 const AUTH_URL = "https://auth.mock.local";
 const API_URL = "https://api.mock.local";
 const TARGET = "https://db-api.mock.local";
+const COLLECTEUR = "https://collecteur.example";
 const ACCOUNT_TOKEN = "tk-us-COMPTE-SECRET";
 
 const originalFetch = globalThis.fetch;
@@ -209,6 +210,58 @@ Deno.test({
       await res.body?.cancel();
 
       assertEquals(stub.calls[1].url, `${API_URL}/v1/apps/mon-app/addons/ad-1111/token`);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+// --- AC-43.18 : contrainte d'hote sur apiUrl (ADR-0009) ---
+
+Deno.test({
+  name: "AC-43.18: un apiUrl hors domaine Scalingo ne recoit jamais le bearer echange",
+  fn: async () => {
+    setup();
+    try {
+      const stub = stubScalingo();
+      const blob = await makeBlob({ apiUrl: COLLECTEUR });
+
+      const res = await proxyApp().request(`/${blob}/api/databases/ad-1111/stats`, {
+        headers: { "X-FGP-Key": CLIENT_KEY },
+      });
+      const body = await res.json();
+
+      // Le refus est le moyen, la non-fuite est la propriete. Un collecteur qui repondrait
+      // un JSON quelconque produirait le meme 502 sans la garde : c'est l'absence d'appel
+      // portant le credential qui distingue les deux etats.
+      const versCollecteur = stub.calls.filter((call) => call.url.startsWith(COLLECTEUR));
+      assertEquals(
+        versCollecteur.length,
+        0,
+        `${versCollecteur.length} appel(s) emis vers l'hote collecteur`,
+      );
+      assertEquals(stub.addonToken, 0);
+      assertEquals(stub.forward, 0, "aucun forward ne part sans token d'addon");
+
+      for (const call of stub.calls) {
+        const serialise = [...call.headers].map(([k, v]) => `${k}: ${v}`).join("\n");
+        assertEquals(
+          serialise.includes("bearer-from-exchange"),
+          false,
+          `bearer echange presente a ${call.url}`,
+        );
+        assertEquals(
+          serialise.includes(ACCOUNT_TOKEN),
+          false,
+          `token de compte presente a ${call.url}`,
+        );
+      }
+
+      assertEquals(res.status, 502);
+      assertEquals(body.error, "auth_addon_failed");
+      assertEquals(res.headers.get(FGP_SOURCE_HEADER), FGP_SOURCE_PROXY);
     } finally {
       teardown();
     }

--- a/tests/testu/auth/client.test.ts
+++ b/tests/testu/auth/client.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import { exchangeToken } from "../../../src/auth/client.ts";
+import { exchangeToken, fetchAddonToken, isScalingoHost } from "../../../src/auth/client.ts";
 
 function stubFetch(
   status: number,
@@ -93,8 +93,56 @@ Deno.test({
   sanitizeResources: false,
 });
 
+Deno.test({
+  name: "AC-43.18 bis: fetchAddonToken n'emet rien vers un apiUrl hors domaine Scalingo",
+  fn: async () => {
+    Deno.env.delete("SCALINGO_API_URL");
+    Deno.env.delete("SCALINGO_AUTH_URL");
+    Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+
+    let calls = 0;
+    globalThis.fetch = (() => {
+      calls++;
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof globalThis.fetch;
+
+    await assertRejects(
+      () => fetchAddonToken("bearer-du-compte", "https://collecteur.example", "app", "ad-1"),
+      Error,
+      "apiUrl host is not a Scalingo host",
+    );
+
+    // La garde vaut par le fetch qui n'a pas lieu : le bearer est deja en main a cet
+    // instant, un refus posterieur a l'emission ne protegerait plus rien.
+    assertEquals(calls, 0, "un appel est parti vers l'hote non Scalingo");
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test("AC-43.18 ter: table des hotes acceptes et des faux amis", () => {
+  const cas: [string, boolean][] = [
+    ["https://api.osc-fr1.scalingo.com", true],
+    ["https://scalingo.com", true],
+    ["https://api.osc-secnum-fr1.scalingo.com/", true],
+    ["https://collecteur.example", false],
+    // Le suffixe se lit sur le hostname, pas sur la chaine : ces trois formes contiennent
+    // toutes « scalingo.com » et aucune n'est un hote Scalingo.
+    ["https://scalingo.com.collecteur.example", false],
+    ["https://evil-scalingo.com", false],
+    ["https://collecteur.example/api.osc-fr1.scalingo.com", false],
+    ["https://collecteur.example?h=scalingo.com", false],
+    ["scalingo.com", false],
+    ["file:///etc/passwd", false],
+  ];
+  for (const [url, attendu] of cas) {
+    assertEquals(isScalingoHost(url), attendu, url);
+  }
+});
+
 globalThis.addEventListener("unload", () => {
   globalThis.fetch = originalFetch;
   Deno.env.delete("SCALINGO_AUTH_URL");
+  Deno.env.delete("SCALINGO_API_URL");
   Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
 });

--- a/tests/testu/crypto/bounded.test.ts
+++ b/tests/testu/crypto/bounded.test.ts
@@ -1,0 +1,117 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { encodeBase64Url } from "@std/encoding/base64url";
+
+import {
+  DecompressionTooLargeError,
+  MAX_DECOMPRESSED_BYTES,
+  readBounded,
+} from "../../../src/crypto/bounded.ts";
+import { decryptBlob, deriveKey } from "../../../src/crypto/blob.ts";
+import { decodePublicConfig } from "../../../src/crypto/share.ts";
+
+const CLIENT_KEY = "bounded-test-key-padding-0123";
+const SERVER_SALT = "bounded-test-salt";
+
+const IV_LENGTH = 12;
+const BOMB_PLAIN_BYTES = 3 * 1024 * 1024;
+
+async function gzip(data: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
+  const stream = new Blob([data as Uint8Array<ArrayBuffer>]).stream().pipeThrough(
+    new CompressionStream("gzip"),
+  );
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** 3 Mo de zeros compressent en quelques Ko : c'est la bombe nommee par l'ADR-0010 D5. */
+function gzipBomb(): Promise<Uint8Array<ArrayBuffer>> {
+  return gzip(new Uint8Array(BOMB_PLAIN_BYTES));
+}
+
+/**
+ * Chiffre un contenu gzip arbitraire sous la forme d'un blob FGP, ce qu'encryptBlob ne
+ * permet pas : il ne compresse que du JSON de configuration valide.
+ */
+async function blobFromGzip(compressed: Uint8Array<ArrayBuffer>): Promise<string> {
+  const key = await deriveKey(CLIENT_KEY, SERVER_SALT);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, compressed),
+  );
+  const raw = new Uint8Array(IV_LENGTH + encrypted.length);
+  raw.set(iv, 0);
+  raw.set(encrypted, IV_LENGTH);
+  return encodeBase64Url(raw);
+}
+
+Deno.test("AC-47.8: une bombe gzip presentee comme blob est rejetee", async () => {
+  const bomb = await gzipBomb();
+  assertEquals(
+    bomb.byteLength < 16 * 1024,
+    true,
+    `la bombe doit rester petite a l'entree, mesuree a ${bomb.byteLength} octets`,
+  );
+
+  const blob = await blobFromGzip(bomb);
+  const err = await assertRejects(
+    () => decryptBlob(blob, CLIENT_KEY, SERVER_SALT),
+    Error,
+  );
+  assertStringIncludes(err.message, "Decompression failed");
+});
+
+Deno.test("AC-47.8 bis: la meme bombe presentee comme encoded de partage est rejetee", async () => {
+  const bomb = await gzipBomb();
+  const encoded = encodeBase64Url(bomb);
+
+  // Le plafond d'entree de /api/share/decode est de 8192 caracteres : la bombe passe
+  // sous ce plafond, c'est tout l'interet de l'amplification.
+  assertEquals(
+    encoded.length < 8192,
+    true,
+    `l'encoded doit passer le plafond d'entree, mesure a ${encoded.length} caracteres`,
+  );
+
+  await assertRejects(
+    () => decodePublicConfig(encoded),
+    DecompressionTooLargeError,
+  );
+});
+
+Deno.test("AC-47.8 ter: la lecture s'arrete au depassement au lieu de tout materialiser", async () => {
+  const CHUNK = 64 * 1024;
+  const CHUNKS = 200;
+  let pulled = 0;
+
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled++;
+      controller.enqueue(new Uint8Array(CHUNK));
+    },
+  });
+
+  await assertRejects(() => readBounded(stream), DecompressionTooLargeError);
+
+  // Le plafond est atteint au troisieme chunk : au-dela, la sortie aurait ete
+  // materialisee avant d'etre jugee, ce qui est exactement la regression a attraper.
+  const maxPulls = Math.ceil(MAX_DECOMPRESSED_BYTES / CHUNK) + 1;
+  assertEquals(
+    pulled <= maxPulls,
+    true,
+    `${pulled} chunks tires pour un plafond de ${maxPulls}`,
+  );
+});
+
+Deno.test("AC-47.8 quater: un flux sous le plafond est lu integralement", async () => {
+  const size = MAX_DECOMPRESSED_BYTES - 1;
+  const payload = new Uint8Array(size).fill(7);
+  const stream = new Blob([payload as Uint8Array<ArrayBuffer>]).stream();
+
+  const out = await readBounded(stream);
+  assertEquals(out.byteLength, size);
+  assertEquals(out[0], 7);
+  assertEquals(out[size - 1], 7);
+});


### PR DESCRIPTION
Le backfill du registre d'AC a révélé **20 décisions d'architecture implémentées mais non testées** sur le lot de sécurité. Aucune régression, mais 20 garanties qu'un refactor peut retirer sans que rien ne s'allume. Cette PR couvre les quatre dont la perte serait la plus chère.

## Ce que la vérification par mutation a montré

C'est le vrai résultat de cette PR. Pour chacun des quatre, la garde a été retirée puis remise, et deux cas ne se laissent pas couvrir naïvement.

**AC-43.18**, la contrainte `.scalingo.com` sur `apiUrl`. Garde retirée, le proxy renvoie **quand même** 502 `auth_addon_failed`, parce que l'hôte collecteur ne répond pas la forme `{addon: {token}}` attendue. Un test qui se serait contenté d'asserter le refus serait donc resté vert sur du code qui livre le bearer Scalingo fraîchement échangé à un tiers, pendant que l'utilisateur voit une simple erreur. Le test compte donc les appels émis vers l'hôte non Scalingo : le refus est le moyen, la non-fuite est la propriété.

**AC-47.8**, la borne de décompression. Même piège. En remplaçant `readBounded` par un `arrayBuffer()`, la bombe gzip de 3 Mo est matérialisée puis rejetée par `JSON.parse` : le rejet a lieu, la protection n'existe plus. Les tests attrapent sur le type d'erreur et sur le nombre de chunks tirés. La propriété « la mémoire du processus ne monte pas » est traduite en nombre de chunks plutôt qu'en RSS, qui serait instable en CI.

**AC-44.9**, l'émission de la forme brute du chemin. En émettant `canonicalizePath(proxyPath)`, c'est-à-dire littéralement l'option rejetée par l'ADR-0009 section 3, **seuls ces 4 tests échouent sur 680**. Les huit tests AC-44 existants restent verts : ils couvrent tous la moitié contrôle de la garantie, aucun la moitié émission.

**AC-45.4**, les en-têtes nommés par `Connection`. L'indirection retirée, `Connection` lui-même reste strippé par la denylist, donc les tests voisins restent verts et seuls ceux-ci attrapent les `X-Custom-A` et `X-Custom-B` relayés. C'est bien le scénario réaliste d'un refactor, pas un strip cassé en grand.

`git diff --stat HEAD -- src/` est vide, `src/` est intact.

## Nommage

Un test portait déjà le numéro AC-45.4 pour un critère différent, les en-têtes de provenance, qui est AC-45.5 au registre. Les nouveaux sont suffixés `(registre v5)` avec un renvoi à la matrice, plutôt que de créer deux tests homonymes couvrant des critères différents, ce qui est exactement le critère de sortie que la tâche de renumérotation s'est fixé.

Certains critères demandent plus d'un test, d'où des suffixes `bis`, `ter`, `quater` qui n'existent pas au registre. La matrice devra les recenser sous leur critère parent.

## Ce qui reste

16 trous, dont deux qui méritent d'être traités vite : AC-50.7 et AC-50.8, la pré-validation avant dérivation PBKDF2, que l'ADR-0010 demande nommément avec un espion de comptage sur `deriveKey`. Le pattern est désormais établi dans `tests/testu/auth/client.test.ts`.

## Vérification

`deno task verify` vert, **680 tests, 0 échec**, contre 667 avant.