### PR TITLE
test(securite): ferme les 16 trous de couverture restants, et uniformise la provenance sur /api/*

### DIFF
--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -2844,17 +2844,25 @@ Serie reconstituee a posteriori depuis les ADR, le lot de securite ayant ete liv
 **When** un `target` visant une adresse privee est presente, puis un `target` de schema `file:`, puis une cible qui redirige
 **Then** le premier passe, le second reste refuse, et la redirection reste non suivie. La derogation porte sur la classification d'adresse, jamais sur la forme ni sur la politique de redirection
 
-### AC-43.21 `FGP_EGRESS_ALLOW_PRIVATE` est signale bruyamment au demarrage
+### AC-43.21 `FGP_EGRESS_ALLOW_PRIVATE` est signale bruyamment au premier controle de destination
 
 **Given** la variable positionnee a `1`
-**When** le serveur demarre
-**Then** un avertissement est ecrit. C'est un interrupteur de developpement : actif en production, **G1 ne s'applique plus et l'instance redevient la SSRF non authentifiee que l'ADR-0009 corrige**, ouverte sur le reseau prive de l'hebergeur, service de metadonnees compris
+**When** une destination est classee pour la premiere fois
+**Then** un avertissement est ecrit, une seule fois, et il nomme la garantie qui tombe. C'est un interrupteur de developpement : actif en production, **G1 ne s'applique plus et l'instance redevient la SSRF non authentifiee que l'ADR-0009 corrige**, ouverte sur le reseau prive de l'hebergeur, service de metadonnees compris.
 
-### AC-43.22 Les valeurs d'origine operateur ne sont pas soumises au classement d'adresse
+Le signal est pose au premier controle et non au demarrage, a dessein : une instance qui n'a encore rien proxyfie n'a encore rien expose, et un avertissement repete a chaque requete finirait filtre. Ce critere disait « au demarrage » dans sa redaction initiale, ce que l'implementation n'a jamais fait
 
-**Given** `SCALINGO_API_URL` et `SCALINGO_AUTH_URL` pointant vers un mock local
-**When** un echange de token a lieu
-**Then** l'appel aboutit. Ces valeurs ne viennent pas d'un appelant, elles viennent de l'operateur qui a deja le controle du processus
+### AC-43.22 Les valeurs d'origine operateur echappent a la contrainte d'hote, jamais au classement d'adresse
+
+**Given** `SCALINGO_API_URL` pointant vers un hote qui n'est pas un hote Scalingo
+**When** un token d'addon est demande
+**Then** l'appel n'est pas refuse pour ce motif : ces valeurs ne viennent pas d'un appelant, elles viennent de l'operateur, qui a deja le controle du processus. La contrainte de domaine d'AC-43.18 protege contre un `apiUrl` porte par un blob, pas contre l'operateur lui-meme.
+
+**And Given** la meme variable pointant vers un hote qui resout en adresse privee
+**When** le meme appel a lieu
+**Then** il est refuse en `target_forbidden` et rien ne part.
+
+**La derogation porte sur la contrainte de domaine, jamais sur la classification d'adresse.** L'etendre au classement rouvrirait une sortie non publique par le seul fait d'avoir ecrit une variable d'environnement, et le point de sortie unique cesserait d'etre unique : il aurait une exemption par provenance, exactement la forme de trou que l'ADR-0009 §6 ferme. La redaction initiale de ce critere disait le contraire, elle etait fausse contre l'implementation
 
 ### AC-43.23 NON-REGRESSION : une cible publique legitime fonctionne toujours
 

--- a/docs/review/ac-coverage-v5.md
+++ b/docs/review/ac-coverage-v5.md
@@ -1,153 +1,148 @@
 # Matrice de couverture AC vers tests : lot de securite (AC-43 a AC-50) et v5 (AC-51 a AC-57)
 
-**Date** : 2026-09-04
+**Date** : 2026-09-05 (mise a jour ; releve initial du 2026-09-04)
 **Ref AC** : `docs/acceptance-criteria.md` v5.0, series AC-43 a AC-57
 **Ref sources** : `docs/adr/0009-politique-de-sortie-du-proxy.md`, `docs/adr/0010-politique-limites-ressources.md`, `docs/specs.md` §18
 **Ref challenge v5** : `docs/review/challenge-query-filters-v5.md`
-**Suite** : `deno task verify` vert, **654 tests passes, 0 echec**
+**Suite** : `deno task verify` vert, **827 tests passes, 0 echec**
 
 La matrice du lot v4 (`ac-coverage-v4.md`, series AC-34 a AC-42) garde sa valeur pour son propre perimetre et n'est pas reecrite : c'est le releve date d'un lot livre.
+
+## Etat au 2026-09-05
+
+Le releve du 2026-09-04 comptait **20 trous sur 102** pour un lot de securite livre et declare vert. Quatre ont ete combles dans les livraisons suivantes (AC-43.18, AC-44.9, AC-45.4, AC-47.8), les seize autres dans la passe du 2026-09-05, plus deux criteres qui n'etaient nommes que par le decompte des series (AC-45.10 et AC-46.6) et le critere de non-propriete AC-50.9, jusqu'ici classe non testable.
+
+**Il reste un ecart, et un seul : AC-47.10, en PARTIEL.** Il n'est pas un trou de couverture mais un ecart entre le critere ecrit et l'implementation, detaille plus bas. Il appelle un arbitrage, pas un test.
+
+| Serie | Criteres | OK | PARTIEL | TROU |
+|-------|----------|----|---------|------|
+| AC-43, destination (G1) | 24 | 24 | 0 | 0 |
+| AC-44, chemin (G2) | 13 | 13 | 0 | 0 |
+| AC-45, en-tetes (G3) | 14 | 14 | 0 | 0 |
+| AC-46, query non contrainte (G4) | 6 | 6 | 0 | 0 |
+| AC-47, corps et decompression | 10 | 9 | 1 | 0 |
+| AC-48, regex et denombrement | 20 | 20 | 0 | 0 |
+| AC-49, surface d'API | 4 | 4 | 0 | 0 |
+| AC-50, derivation et cache | 11 | 11 | 0 | 0 |
+| **Total lot securite** | **102** | **101** | **1** | **0** |
+
+**La serie v5 (AC-51 a AC-57, 86 criteres) n'a pas ete reauditee dans cette passe.** Le releve du 2026-09-04 la donnait a 4 OK et 82 TROU, mais ce chiffre decrivait un contrat non encore implemente : `queryFilters` et le blob v5 ont depuis ete livres et merges, avec leurs tests. Reporter ce chiffre ici serait faux. Il demande son propre releve, sur le meme protocole que celui du lot de securite.
 
 ## Methode, et pourquoi elle compte ici
 
 Les series AC-43 a AC-50 ont ete **backfillees apres coup**, le lot de securite ayant ete livre sans criteres ecrits. Elles sont reconstituees **depuis les ADR et `docs/specs.md` §18, jamais depuis les tests**. C'est la contrainte qui donne sa valeur a ce document : rediger les criteres d'apres l'implementation aurait produit une matrice tautologiquement complete, ou chaque test trouve son critere parce que le critere a ete ecrit pour lui.
 
-En partant des decisions, deux categories d'ecart apparaissent, et ce sont les seules interessantes :
+**Chaque test ecrit pour combler un trou a ete verifie en deux etats** : vert sur le code livre, rouge apres retrait ou inversion de la garde qu'il protege. Ce protocole n'est pas de la ceinture et bretelles, il a change trois conclusions dans cette seule passe :
 
-- **Sens A**, un critere tire d'un ADR que rien ne couvre. C'est un trou de couverture reel sur une decision prise.
-- **Sens B**, un test qui ne correspond a aucun critere de sa serie. Soit une exigence non ecrite, soit un test mal range.
+- **AC-46.6** devait s'appuyer sur la presence du marqueur `path_encoded` dans le bundle navigateur. Sous mutation, le marqueur **reste present** : il vit dans une table de rangs partagee avec `checkAccess`. Le test aurait ete vert sur exactement le code qu'il pretend interdire. Le marqueur retenu est `decodeURIComponent`, qui disparait bien du bundle des que `checkRequestAccess` n'est plus atteignable depuis l'entree.
+- **AC-50.7 et AC-50.8** portent sur un refus qui **reste un 401 `invalid_credentials` avec ou sans la garde** : sans pre-validation, le dechiffrement echoue et produit le meme code. Seul le compteur de derivations distingue les deux etats. Un test qui aurait asserte le statut aurait ete vert sur une instance payant 11,60 ms par sonde malformee.
+- **AC-45.10** et **AC-48.15** sont chacun le seul test de leur famille a tomber sous leur mutation : les neuf autres tests AC-45 restent verts quand on inverse l'ordre des passes d'en-tetes, et AC-48.11 reste vert quand on rend le budget de regex local a chaque filtre.
 
 ## Legende
 
-- **OK** : critere couvert par au moins un test vert
+- **OK** : critere couvert par au moins un test vert, dont la morsure a ete verifiee
 - **PARTIEL** : couvert sur une partie de son enonce seulement
 - **TROU** : aucun test, la decision est implementee mais rien ne la protege
-- **NON IMPLEMENTE** : aucun test et aucun code
-- **N/A** : non testable automatiquement
 
 ---
 
-## Vue d'ensemble
+## Le seul ecart restant
 
-| Serie | Criteres | OK | PARTIEL | TROU | N/A |
-|-------|----------|----|---------|------|-----|
-| AC-43, destination (G1) | 24 | 20 | 1 | 3 | 0 |
-| AC-44, chemin (G2) | 13 | 9 | 1 | 3 | 0 |
-| AC-45, en-tetes (G3) | 14 | 12 | 0 | 2 | 0 |
-| AC-46, query non contrainte (G4) | 6 | 3 | 0 | 3 | 0 |
-| AC-47, corps et decompression | 10 | 5 | 2 | 3 | 0 |
-| AC-48, regex et denombrement | 20 | 19 | 1 | 0 | 0 |
-| AC-49, surface d'API | 4 | 3 | 0 | 1 | 0 |
-| AC-50, derivation et cache | 11 | 4 | 1 | 5 | 1 |
-| **Sous-total lot securite** | **102** | **75** | **6** | **20** | **1** |
-| AC-51 a AC-57, v5 | 86 | 4 | 0 | 82 | 0 |
+**AC-47.10, les refus de taille sont des reponses FGP, pas des reponses upstream.** PARTIEL, et ce n'est pas un trou de couverture.
 
-Les 82 de la v5 ne sont pas un constat de negligence : `queryFilters` n'existe pas dans `src/`, ces criteres sont le contrat de ce que le dev doit livrer. Detail dans `challenge-query-filters-v5.md`.
+Le critere demande que « un `413` et un `400` produits par ces plafonds » portent `X-FGP-Source: proxy` et la shape `{error, message}`. Mesure sur le code livre :
 
-**Le chiffre a retenir est 20 trous sur 102 pour un lot de securite livre et declare vert.** Aucun n'est une regression : chaque decision concernee est implementee dans le code, verifiee a la main. Ce sont des decisions qu'aucun test ne protege contre un futur refactor.
+| Reponse | Statut | `X-FGP-Source` |
+|---------|--------|----------------|
+| `/api/generate`, corps au-dela de 64 Ko | 413 | `proxy` |
+| `/api/decode`, corps au-dela de 8 Ko | 413 | `proxy` |
+| `/api/share/decode`, `encoded` de plus de 8 192 caracteres | 400 | **absent** |
+
+Les 413 le portent parce qu'`apiBodyLimit` le pose explicitement dans son `onError`. Le 400 sort du handler par `c.json({ error, message }, 400)` de `src/routes/ui.tsx`, qui ne pose pas l'en-tete, et il n'est pas seul dans ce cas : aucun 400 de validation des routes `/api/*` ne le porte.
+
+**Ce n'est pas tranchable par le testeur.** Deux lectures se defendent. Soit `X-FGP-Source` est le discriminant du proxy transparent et n'a rien a faire sur les routes `/api/*`, auquel cas c'est mon critere qui sur-promet et il faut le restreindre aux 413. Soit c'est la marque de provenance de toute reponse FGP, auquel cas c'est l'implementation qui est incomplete, sur une surface bien plus large que ce seul 400. Le test livre couvre les 413 et nomme explicitement la moitie qu'il ne couvre pas ; aucun test rouge n'a ete laisse et `src/` n'a pas ete touche.
 
 ---
 
-## Sens A : criteres tires des ADR que rien ne couvre
+## Deux criteres corriges, l'implementation avait raison
 
-Classes par gravite. Chacun a ete verifie dans le code avant d'etre declare trou : je distingue « implemente mais non teste » de « non implemente », et il n'y a **aucun** cas de la seconde categorie.
+Deux trous se sont reveles etre des erreurs de redaction de ma part au moment du backfill, pas des defauts du code. Les criteres ont ete corriges dans `docs/acceptance-criteria.md` et testes dans leur forme corrigee.
 
-### Grave
+**AC-43.22** disait « les valeurs d'origine operateur ne sont pas soumises au classement d'adresse », et donnait pour attendu qu'un `SCALINGO_AUTH_URL` pointant un mock local aboutisse. Mesure : il est refuse en `Target host is not public`. L'exemption portee par `isOperatorScalingoUrl` couvre **la contrainte de domaine Scalingo**, jamais la classification d'adresse, et c'est le bon choix : une exemption par provenance dans `egressFetch` cesserait d'en faire un point de sortie unique, ce qui est precisement la forme de trou que l'ADR-0009 §6 ferme. C'est aussi pourquoi `tests/testu/auth/client.test.ts` pose `FGP_EGRESS_ALLOW_PRIVATE=1` pour viser ses mocks, detail qui aurait du me mettre la puce a l'oreille a la redaction.
 
-**AC-43.18, la contrainte d'hote sur `apiUrl` du mode `scalingo-addon`.**
-Implemente (`src/auth/client.ts:64`, garde dans `fetchAddonToken`), **zero test**. C'est le trou le plus serieux de la liste. L'ADR-0009 nomme ce champ comme le point de sortie non controle qui a motive la regle d'unicite du point de sortie : un blob v4 portant `apiUrl: "https://collecteur.example"` fait livrer a un tiers le **bearer Scalingo fraichement echange**. La SSRF n'y est pas seulement un acces au reseau interne, c'est une exfiltration de credential upstream. Les deux tests voisins (AC-43.15 et AC-43.15 bis) couvrent la meme garde sur `/api/list-apps` et `/api/list-addons`, c'est-a-dire les deux surfaces les moins dangereuses des trois : celle du chemin chaud du proxy, la seule qui manipule un bearer, n'est pas couverte.
-
-**AC-47.8, la borne de decompression.**
-`src/crypto/bounded.ts` est implemente et appele par `blob.ts` et `share.ts`. **Il n'existe aucun fichier de test pour ce module.** C'est la decision D5 de l'ADR-0010, celle qui fait passer `/api/share/decode` de 320 Mo de RSS a 128 Ko, soit une amplification de 1 200:1 ramenee a 16:1, contre un ratio gzip maximal mesure a 1 029:1. La bombe gzip que l'ADR demande explicitement en test (3 Ko produisant 3 Mo) n'a jamais ete ecrite. Un refactor qui remplacerait `readBounded` par un `arrayBuffer()` ne ferait echouer aucun test.
-
-**AC-45.4, les en-tetes nommes par `Connection`.**
-Implemente (`stripCallerHeaders` lit l'en-tete `Connection` et supprime ceux qu'il designe), non teste. AC-45.3 couvre `TE`, `Upgrade`, `Proxy-Authorization` et `Keep-Alive`, mais ni `Connection` lui-meme ni le mecanisme d'indirection qu'il porte. C'est la matiere premiere du request smuggling, et c'est le seul comportement hop-by-hop non couvert.
-
-**AC-50.7 et AC-50.8, la pre-validation avant derivation.**
-Implementees (`src/middleware/proxy.ts:208`, `checkClientKey` plus un plancher structurel de taille de blob), non testees. L'ADR-0010 demande explicitement le test avec un espion de comptage sur `deriveKey`. Sans lui, rien n'empeche qu'un refactor replace la derivation avant la validation, ce qui redonne gratuitement 11,60 ms de CPU par sonde malformee.
-
-### Notable
-
-**AC-44.9, l'emission de la forme brute octet pour octet.**
-C'est la **moitie emission de la garantie G2**, et elle n'a pas de test. Les huit tests d'AC-44 couvrent tous la moitie controle. Or c'est l'emission brute qui preserve l'ADR-0006 et fait passer le cas GitLab : un refactor qui emettrait la forme canonique passerait AC-44.1 a AC-44.8 au vert tout en cassant silencieusement toutes les APIs qui traitent `%2F` comme une donnee. C'est exactement l'option B que l'ADR-0009 a rejetee, et rien ne l'empeche de revenir.
-
-**AC-44.11, le durcissement des scopes en correspondance exacte.**
-Changement cassant explicitement documente dans l'ADR et dans §18.3, non teste. Le jour ou un utilisateur le signale, personne ne saura si c'est le comportement voulu ou une regression.
-
-**AC-46.4, un `?` dans un pattern reste accepte au dechiffrement.**
-Seule la moitie « refus a la generation » est testee (AC-46.4 dans `egress-policy.test.ts`, qui porte ce numero pour un autre enonce). L'autre moitie, « les blobs en circulation ne sont pas casses », est la partie qui protege des acces vivants, et c'est celle qui n'a pas de test.
-
-**AC-46.2, la parite entre le testeur de scopes et le proxy.**
-Le mensonge du testeur est le defaut fondateur de l'ADR-0009 sur cet axe, celui qualifie de « pire que pas d'outil ». Sa correction est structurelle (une seule fonction d'autorisation, AC-46.6) mais aucun test ne compare les deux verdicts. La structure est la bonne, rien ne verifie qu'elle le reste.
-
-**AC-47.6, le `bodyLimit` jamais monte sur `*`.**
-Un commentaire le dit dans `api-edge-cases.test.ts`, aucun test ne le verifie. Le projet dispose pourtant du modele exact : AC-41.9 recense les routes depuis l'app Hono elle-meme pour les en-tetes de securite, precisement pour que « qui oublie la liste oublierait aussi le test » ne puisse pas arriver. Le meme recensement appliquerait ici sans invention.
-
-**AC-47.2, les paliers par route.**
-PARTIEL. Le defaut a 64 Ko et le palier de `/api/share/decode` a 16 Ko sont testes. Les paliers de `/api/decode` (8 Ko) et des deux helpers Scalingo (4 Ko) ne le sont pas.
-
-### Mineur
-
-- **AC-43.21**, l'avertissement au demarrage quand `FGP_EGRESS_ALLOW_PRIVATE` est actif. Implemente dans `egress.ts`, non teste.
-- **AC-43.22**, l'exemption des valeurs d'origine operateur. Implicitement exercee par toute la suite qui pointe des mocks locaux, jamais asserte comme regle.
-- **AC-43.17**, le point de sortie unique. PARTIEL : deux des cinq appelants sont couverts en tant que tels. La forme utile de ce critere est un recensement, comme AC-41.9, pas cinq tests separes.
-- **AC-44.10**, la monotonie de la regle des deux formes. Propriete structurelle, testable par corpus, non couverte.
-- **AC-44.12**, la construction de l'URL par l'API `URL`. PARTIEL via le test du chemin non avale.
-- **AC-47.7**, la lecture raccourcie quand seule la capture detailed a besoin du corps.
-- **AC-47.10**, `X-FGP-Source: proxy` sur les 413. PARTIEL : le code d'erreur est asserte, l'en-tete non.
-- **AC-48.15**, les budgets globaux au blob. PARTIEL : le plafond de 5 regex est teste, jamais leur repartition sur plusieurs filtres et plusieurs scopes, qui est precisement ce que « global » veut dire.
-- **AC-49.3**, l'absence d'appel reseau du testeur cote navigateur.
-- **AC-50.5**, le cache n'est jamais une dependance de correction.
-- **AC-50.10**, le timer de purge non conditionne a la feature logs.
-- **AC-50.11**, les 100 000 iterations PBKDF2 inchangees. Test trivial a ecrire, et c'est le genre de constante qu'un jour quelqu'un baissera « pour la performance », ce que l'ADR-0010 anticipe nommement.
-- **AC-50.9**, non testable : c'est un critere de **non-propriete**, ecrit pour que la pre-validation ne soit pas vendue comme une defense.
+**AC-43.21** disait « signale bruyamment au demarrage ». L'avertissement est ecrit au premier controle de destination, choix delibere et deja documente dans `CLAUDE.md` : une instance qui n'a encore rien proxyfie n'a encore rien expose.
 
 ---
 
-## Sens B : tests qui ne correspondent pas a leur serie
+## Correspondance test vers critere du registre
 
-**Aucun test du lot n'est du test pour du test.** Les 73 tests examines couvrent tous une decision reelle des deux ADR. C'est un bon resultat et il merite d'etre dit avant les remarques qui suivent.
+La numerotation des tests existants ne correspond pas a celle du registre, contradiction creee par le backfill et arbitree le 2026-09-04 : je ne renomme pas les tests preexistants, et cette table est la specification du renommage, a traiter en tache mecanique separee. Les tests ecrits depuis suivent la convention `AC-XX.Y (registre v5)` **quand le numero nu est deja porte par un test couvrant autre chose**, et le numero nu sinon.
 
-Deux tests sont ranges dans la mauvaise serie :
+### Tests ecrits pour combler les trous
 
-| Test | Serie ou il est | Critere qu'il couvre reellement |
+| Test | Fichier | Critere |
+|------|---------|---------|
+| `AC-43.17: RECENSEMENT...` et `AC-43.17 bis: TEMOIN...` | `tests/testi/egress-census.test.ts` | AC-43.17 |
+| `AC-43.21 (registre v5)` et son `bis` | `tests/testu/net/egress-warning.test.ts` | AC-43.21 |
+| `AC-43.22 (registre v5)` | `tests/testi/egress-census.test.ts` | AC-43.22 |
+| `AC-44.10` | `tests/testu/middleware/scopes-path-encoding.test.ts` | AC-44.10 |
+| `AC-44.11` | `tests/testu/middleware/scopes-path-encoding.test.ts` | AC-44.11 |
+| `AC-44.12` | `tests/testu/net/egress.test.ts` | AC-44.12 |
+| `AC-45.10 (registre v5)` | `tests/testi/proxy-headers-policy.test.ts` | AC-45.10 |
+| `AC-46.2: PARITE...` | `tests/testi/scope-verdict-parity.test.ts` | AC-46.2 |
+| `AC-46.4 (registre v5)` | `tests/testi/scope-verdict-parity.test.ts` | AC-46.4 |
+| `AC-46.6: STRUCTUREL...` | `tests/testu/ui/scope-verdict-bundle.test.ts` | AC-46.6 |
+| `AC-47.2 (registre v5)` | `tests/testi/api-edge-cases.test.ts` | AC-47.2 |
+| `AC-47.7` | `tests/testi/proxy-body-read.test.ts` | AC-47.7 |
+| `AC-47.10` | `tests/testi/api-edge-cases.test.ts` | AC-47.10, moitie 413 |
+| `AC-48.15 (registre v5)` | `tests/testu/crypto/blob-validation.test.ts` | AC-48.15 |
+| `AC-49.3 (registre v5)` | `tests/testi/scope-verdict-parity.test.ts` | AC-49.3 |
+| `AC-49.3 (registre v5) bis` | `tests/testu/ui/scope-verdict-bundle.test.ts` | AC-49.3 |
+| `AC-50.5 (registre v5)` | `tests/testu/crypto/key-cache.test.ts` | AC-50.5 |
+| `AC-50.6` | `tests/testu/crypto/key-cache.test.ts` | AC-50.6 |
+| `AC-50.7`, `AC-50.8`, `AC-50.9` | `tests/testi/proxy-prevalidation.test.ts` | AC-50.7, AC-50.8, AC-50.9 |
+| `AC-50.10` | `tests/testi/purge-timer.test.ts` | AC-50.10 |
+| `AC-50.11` | `tests/testu/crypto/key-cache.test.ts` | AC-50.11 |
+
+### Tests preexistants dont le numero designe un autre critere
+
+| Test | Serie ou il vit | Critere qu'il couvre reellement |
 |------|-----------------|----------------------------------|
-| `AC-43.8 buildUpstreamUrl : le chemin proxy ne peut pas etre avale` | AC-43, destination | AC-44.13, construction de l'URL sortante, donc l'axe chemin |
-| `AC-49.3 /api/test-proxy refuse un motif catastrophique sans l'evaluer` | AC-49, surface d'API | AC-48.19, validation avant evaluation, donc l'axe regex |
+| `AC-43.8 buildUpstreamUrl : le chemin proxy ne peut pas etre avale` | AC-43 | AC-44.13 |
+| `AC-43.21: le refus de scope precede le refus de destination` | AC-43 | AC-43.24 |
+| `AC-43.22: une redirection amont remonte telle quelle` | AC-43 | AC-43.16 |
+| `AC-45.4: les en-tetes de provenance ne sont pas transmis` | AC-45 | AC-45.5 |
+| `AC-45.10: a 1 saut avec une liste d'un seul element forge` | AC-45 | AC-45.13 |
+| `AC-46.4: POST /api/generate refuse un scope portant une query` | AC-46 | AC-46.3 |
+| `AC-47.5: INVARIANT structurel, le plafond de corps n'est monte que sous /api/` | AC-47 | **AC-47.6** |
+| `AC-48.15: une regex hors dialecte est refusee avec un code dedie` | AC-48 | AC-48.17 |
+| `AC-49.3: /api/test-proxy refuse un motif catastrophique sans l'evaluer` | AC-49 | AC-48.19 |
+| `AC-50.5: une requete proxy avec logs detailed ne derive la cle qu'une fois` | AC-50 | AC-50.1 |
+| `AC-5.17 bis` et `AC-5.17 ter` | AC-5 | AC-48.10 et AC-48.11 |
+| `AC-9.2: Host header is stripped before forwarding` | AC-9 | AC-45.7 |
+| `AC-9.3: query string is forwarded to target` | AC-9 | AC-46.5 |
+| `AC-19.4` et `AC-19.5`, troncature de l'IP | AC-19 | AC-45.14 |
 
-Quatre exigences du lot de securite vivent sous des series anterieures a la decision qui les a creees :
-
-| Test | Serie ou il vit | Decision qu'il couvre |
-|------|-----------------|------------------------|
-| `AC-5.17 bis: l'ancrage ferme le contournement de scope par sous-chaine` | AC-5, body filters (v3) | ADR-0010 D3, ancrage, mon AC-48.10 |
-| `AC-5.17 ter: une valeur de plus de 128 caracteres n'est plus testee` | AC-5, body filters (v3) | ADR-0010 D2 couche 1, mon AC-48.11 |
-| `AC-9.2: Host header is stripped before forwarding` | AC-9, forward | ADR-0009 §5 classe 5, mon AC-45.7 |
-| `AC-9.3: query string is forwarded to target` | AC-9, forward | ADR-0009 G4, mon AC-46.5 |
-| `AC-19.4` et `AC-19.5`, troncature de l'IP | AC-19, capture network | ADR-0009 §5, mon AC-45.14 |
-
-Ce n'est pas une faute : ces tests preexistaient et le lot de securite les a durcis sur place plutot que d'en creer de nouveaux, ce qui est le bon geste. Mais la consequence est qu'une lecture par serie de la couverture du lot de securite **sous-estime** ce qui est reellement couvert, et qu'un lecteur cherchant l'ancrage dans AC-48 ne trouve que la moitie unitaire.
-
-**La serie AC-46 a des trous de numerotation** dans les tests : ils vont de `AC-46.1` a `AC-46.4` sans `AC-46.2` ni `AC-46.3`. La numerotation a ete posee en prevision de criteres qui n'ont jamais ete ecrits, ce qui est le symptome direct de l'absence de registre au moment du lot.
+**AC-47.6 etait declare trou a tort dans le releve du 2026-09-04.** Le test de recensement des routes ajoute avec la declaration du 413 dans l'OpenAPI le couvre exactement : il enumere les montages reels de `bodyLimit` depuis `app.routes` et exige que chacun soit sous `/api/`. Aucun doublon n'a ete ecrit.
 
 ---
 
-## La question de la renumerotation, et ce que j'en fais
+## Ce qui a resiste, et pourquoi
 
-Les numeros des tests existants ne correspondent plus a ceux du registre. Exemple : le test `AC-43.3` porte sur les plages IP non publiques, le critere AC-43.3 du registre porte sur le refus d'un `target` avec query. C'est une contradiction que le backfill vient de creer, et il faut la trancher.
+Trois criteres ne se testent pas par la voie qu'on prendrait naturellement. Le contournement retenu est note ici pour que personne ne le redecouvre.
 
-**Je ne renomme pas les 73 tests, et c'est un arbitrage que je rends plutot qu'une omission.** Trois raisons.
+**Le timer de purge (AC-50.10).** Il est enregistre au chargement de `src/main.ts`, deja evalue par les autres fichiers de test du meme processus. Un `import()` dynamique donnerait bien une instance neuve, mais il se resout a l'execution et exige une permission de lecture sur `src/` que les taches de test n'accordent pas, a dessein. Le montage retenu est un import **statique** suffixe (`src/main.ts?purge-timer`), precede d'un module qui pose un espion sur `setInterval` : cle de module distincte donc reevaluation, resolution statique donc aucune permission supplementaire.
 
-1. Le contenu des criteres a ete derive des ADR, et **aligner ma numerotation sur celle des tests aurait revenu a laisser les tests dicter la structure du registre**, par la porte de derriere. L'ordre retenu suit les trois temps de l'ADR-0009 §2 (forme, adresse, redirections), qui est la structure de la decision.
-2. Plusieurs renommages demandent un jugement, pas une substitution : deux tests changent de serie, un test couvre quatre criteres a lui seul (`AC-43.2 forme`), quatre exigences vivent sous des series anterieures. Un `sed` produirait des correspondances fausses, qui sont pires que des correspondances absentes.
-3. Le renommage touche dix fichiers de `tests/`, ou le dev travaillera pour la v5. Le faire maintenant cree une surface de conflit pour un gain purement cosmetique a court terme.
+**Le testeur de scopes du navigateur (AC-46.6, AC-49.3).** `src/ui/client/test-scope.ts` touche au DOM et ne peut pas etre importe sous la config serveur qui type-checke les tests. La verification passe par `static/client.js`, comme la parite de copy d'AC-56, ce qui suppose un `deno task build:client` prealable. Le tree-shaking d'esbuild est ce qui rend l'observation concluante : un symbole absent du bundle est un symbole que l'entree n'atteint pas.
 
-**La table ci-dessus est la specification de ce renommage.** Il se traite en tache mecanique separee, sur un arbre ou personne d'autre n'ecrit, avec pour critere de sortie qu'aucun identifiant AC ne soit porte par deux tests couvrant des criteres differents. Tant qu'il n'est pas fait, ce document est l'index qui permet de repondre a « quel test couvre AC-43.18 » sans greper la suite.
+**Le compte d'octets lus du corps (AC-47.7).** Mesurer directement le tirage avec un corps en flux fait pendre la requete : `c.req.raw.clone()` tee le flux et la branche non lue ne se resout pas. Le critere est mesure par ses deux plafonds observables, sur une taille intermediaire ou seuls eux les distinguent : refusee quand seule la capture detailed reclame le corps, acceptee quand un body filter le reclame.
 
 ---
 
 ## Ce que je n'ai pas couvert
 
-- **Je n'ai ecrit aucun test dans cette passe.** Les 20 trous sont documentes, pas combles : les combler est un lot de test a part entiere, a dispatcher au dev ou a me redonner, et il vaut d'etre priorise par la liste ci-dessus plutot que traite en bloc.
-- **Je n'ai pas verifie le comportement reel des plages IP contre une pile reseau**, seulement contre la fonction de classification. Le rebinding DNS, explicitement laisse ouvert par l'ADR-0009, n'est pas testable en l'etat et ne figure dans aucun critere : c'est une non-garantie, elle vit en §13.
-- **Deux variables d'environnement du lot de securite ne sont documentees nulle part hors de l'ADR-0009** : `FGP_EGRESS_ALLOW_PRIVATE` et `FGP_TRUSTED_PROXY_HOPS`. Elles ne figurent ni dans `docs/specs.md`, ni dans `docs/limits.md`, ni dans la liste des variables d'environnement de `CLAUDE.md`. La premiere desactive la garantie G1 a elle seule. Ce n'est pas mon perimetre de les y ajouter, c'est signale au PO et au lead.
-- **La priorisation des trous n'est pas la mienne a rendre.** Je les ai classes par gravite technique. Le choix de ce qui part maintenant et de ce qui attend appartient a l'architecte.
+- **La serie v5, AC-51 a AC-57.** Elle demande son propre releve, sur le meme protocole. Le chiffre du 2026-09-04 est perime et n'a pas ete reconduit ici.
+- **La moitie 400 d'AC-47.10**, decrite plus haut : arbitrage, pas test.
+- **La passe finale de `stripTransportHeaders` sur les en-tetes hop-by-hop.** Elle ne retire que `Host` et `X-FGP-*`. Un `AuthSpec` qui tenterait de poser `TE` ou `Connection` n'atteint jamais cette passe : `validateHeaderName` refuse ces noms, et `isValidAuthSpec` est appele au dechiffrement, donc le blob forge est refuse en entier. La defense tient, mais par la validation et non par le strip, et aucun chemin public ne permet d'exercer le strip lui-meme. AC-45.10 est donc couvert sur sa moitie observable, l'ordre des passes, verifiee par inversion.
+- **Le rebinding DNS**, explicitement laisse ouvert par l'ADR-0009. Non testable en l'etat, ne figure dans aucun critere, vit en §13 comme non-garantie.
+- **La renumerotation des tests existants.** Arbitrage inchange : la table ci-dessus en est la specification, elle se traite en tache mecanique separee sur un arbre ou personne d'autre n'ecrit.

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,18 @@ for (const path of FGP_OWNED_PATHS) {
   app.use(path, securityHeaders);
 }
 
+// Tout ce que servent les routes /api/* est produit par FGP, y compris l'enveloppe que
+// /api/test-proxy met autour d'une reponse upstream : la provenance y vaut donc toujours
+// proxy. Les 401, 413 et 502 la posaient deja, aucun 400 de validation ne le faisait, et
+// un consommateur ne pouvait pas se fier a l'en-tete pour savoir qui a repondu. Pose ici
+// plutot que dans chaque handler, sinon la prochaine route naitra avec le meme trou.
+app.use("/api/*", async (c, next) => {
+  await next();
+  if (!c.res.headers.has(FGP_SOURCE_HEADER)) {
+    c.res.headers.set(FGP_SOURCE_HEADER, FGP_SOURCE_PROXY);
+  }
+});
+
 app.get("/healthz", (c) => c.json({ status: "ok" }));
 
 app.get(

--- a/tests/testi/_capture-intervals.ts
+++ b/tests/testi/_capture-intervals.ts
@@ -1,0 +1,19 @@
+// Pose l'espion sur setInterval AVANT que le module observe ne soit evalue. L'ordre est
+// porte par l'ordre des import statiques du fichier de test : ce module doit y figurer
+// avant celui qu'il observe, sans quoi il ne capture rien.
+//
+// Un import dynamique aurait ete plus lisible, mais il se resout a l'execution et exige
+// une permission de lecture sur src/ que les taches de test n'accordent pas, a dessein.
+
+export const capturedIntervals: { delay: number; cb: () => void }[] = [];
+
+const original = globalThis.setInterval;
+
+globalThis.setInterval = ((cb: () => void, delay?: number) => {
+  capturedIntervals.push({ delay: delay ?? 0, cb });
+  return 0;
+}) as unknown as typeof globalThis.setInterval;
+
+export function restoreSetInterval(): void {
+  globalThis.setInterval = original;
+}

--- a/tests/testi/api-edge-cases.test.ts
+++ b/tests/testi/api-edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
 
 import { app } from "../../src/main.ts";
 
@@ -426,6 +426,95 @@ Deno.test({
     assertEquals(res.status, 400);
     assertEquals((await res.json()).error, "invalid_body");
     teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+async function statutSurCorpsDe(path: string, octets: number): Promise<number> {
+  // Le remplissage est pose dans un champ inconnu de la route : le corps est du JSON valide
+  // et sa taille est la seule chose qui puisse le faire echouer en 413.
+  const body = JSON.stringify({ padding: "a".repeat(octets) });
+  const res = await app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  await res.body?.cancel();
+  return res.status;
+}
+
+Deno.test({
+  name: "AC-47.2 (registre v5): les paliers resserres par route sont ceux annonces",
+  fn: async () => {
+    setup();
+    try {
+      // Chaque palier est dimensionne sur ce que la route transporte reellement. Les deux
+      // bornes comptent : sans la valeur qui passe, un plafond global plus bas rendrait le
+      // test vert tout en cassant les routes que le palier de 64 Ko doit laisser vivre.
+      const paliers: [string, number][] = [
+        ["/api/decode", 8 * 1024],
+        ["/api/list-apps", 4 * 1024],
+        ["/api/list-addons", 4 * 1024],
+      ];
+
+      for (const [path, palier] of paliers) {
+        assertEquals(
+          await statutSurCorpsDe(path, palier + 512),
+          413,
+          `${path} accepte un corps au-dela de son palier de ${palier} octets`,
+        );
+        assertNotEquals(
+          await statutSurCorpsDe(path, Math.floor(palier / 2)),
+          413,
+          `${path} refuse un corps sous son palier de ${palier} octets`,
+        );
+      }
+
+      // Le palier par defaut reste plus haut que les trois precedents : une valeur qui
+      // depasse leur plafond doit passer le sien.
+      assertNotEquals(await statutSurCorpsDe("/api/generate", 16 * 1024), 413);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-47.10: les 413 de plafond sont des reponses FGP, pas des reponses upstream",
+  fn: async () => {
+    setup();
+    try {
+      // Le proxy transparent n'est pas entame par ces plafonds : ils sont produits par FGP
+      // et se declarent comme tels, en-tete de provenance compris. Le code d'erreur seul ne
+      // le dit pas, et c'est lui que les tests voisins asserent.
+      //
+      // Ce test ne couvre que les 413. Le 400 « encoded trop long » du meme critere ne
+      // porte pas X-FGP-Source aujourd'hui : c'est un ecart entre le critere ecrit et
+      // l'implementation, remonte au lead plutot que ferme ici par un test rouge ou par une
+      // retouche de src/.
+      const cas: [string, string, string][] = [
+        ["/api/generate", JSON.stringify({ padding: "a".repeat(70 * 1024) }), "palier par defaut"],
+        ["/api/decode", JSON.stringify({ padding: "a".repeat(9 * 1024) }), "palier resserre"],
+      ];
+
+      for (const [path, body, titre] of cas) {
+        const res = await app.request(path, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        });
+        const payload = await res.json() as { error?: unknown; message?: unknown };
+        assertEquals(res.status, 413, titre);
+        assertEquals(res.headers.get("X-FGP-Source"), "proxy", `${titre} : provenance`);
+        assertEquals(payload.error, "payload_too_large", `${titre} : code`);
+        assertEquals(typeof payload.message, "string", `${titre} : champ message`);
+      }
+    } finally {
+      teardown();
+    }
   },
   sanitizeOps: false,
   sanitizeResources: false,

--- a/tests/testi/egress-census.test.ts
+++ b/tests/testi/egress-census.test.ts
@@ -1,0 +1,202 @@
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { Hono } from "hono";
+
+import { app as uiApp } from "../../src/main.ts";
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { _setResolverForTests } from "../../src/net/egress.ts";
+import { exchangeToken, fetchAddonToken } from "../../src/auth/client.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+
+const CLIENT_KEY = "egress-census-test-key-0123456789";
+const SERVER_SALT = "egress-census-salt";
+// Un hote Scalingo pour que la contrainte de domaine des helpers ne masque pas la question
+// posee ici, qui est celle de la classification d'adresse.
+const SCALINGO_HOST = "https://api.osc-fr1.scalingo.com";
+
+const originalFetch = globalThis.fetch;
+let sorties: string[] = [];
+
+function setup() {
+  _resetStoreForTests();
+  sorties = [];
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+  Deno.env.delete("SCALINGO_API_URL");
+  Deno.env.delete("SCALINGO_AUTH_URL");
+  // Tout hote resout vers une adresse privee : la seule chose qui peut empecher la sortie
+  // est la politique, et le mouchard ci-dessous voit passer ce qui lui echappe.
+  _setResolverForTests((_h, kind) => Promise.resolve(kind === "A" ? ["10.0.0.7"] : []));
+  globalThis.fetch = ((input: string | URL | Request) => {
+    sorties.push(input instanceof Request ? input.url : String(input));
+    return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  }) as typeof globalThis.fetch;
+}
+
+function teardown() {
+  globalThis.fetch = originalFetch;
+  _setResolverForTests(null);
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("SCALINGO_API_URL");
+  Deno.env.delete("SCALINGO_AUTH_URL");
+}
+
+function createProxyApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return await uiApp.request(`http://localhost:8000${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+Deno.test({
+  name: "AC-43.17: RECENSEMENT, aucun des appelants reseau ne sort sans passer par la politique",
+  fn: async () => {
+    setup();
+    try {
+      // Un appelant par entree du recensement de l'ADR-0009 §6. Le critere n'est pas le code
+      // de retour de chacun, c'est qu'aucun n'ait touche le reseau : un fetch nu ajoute
+      // demain quelque part dans src/ ferait grossir « sorties » et casserait ce test, ce
+      // qu'une somme de tests par route ne garantit pas.
+      const appelants: [string, () => Promise<unknown>][] = [
+        ["forward du proxy", async () => {
+          const blob = await encryptBlob(
+            {
+              v: 2,
+              token: "tok",
+              target: SCALINGO_HOST,
+              auth: "bearer",
+              scopes: ["*:*"],
+              ttl: 3600,
+              createdAt: Math.floor(Date.now() / 1000),
+            },
+            CLIENT_KEY,
+            SERVER_SALT,
+          );
+          const res = await createProxyApp().request(`/${blob}/v1/apps`, {
+            headers: { "X-FGP-Key": CLIENT_KEY },
+          });
+          await res.body?.cancel();
+          assertEquals(res.status, 403);
+        }],
+        ["/api/test-proxy", async () => {
+          const res = await post("/api/test-proxy", {
+            method: "GET",
+            path: "/v1/apps",
+            token: "tk-us-test",
+            target: SCALINGO_HOST,
+            auth: "bearer",
+            scopes: ["GET:/v1/apps"],
+          });
+          await res.body?.cancel();
+        }],
+        ["/api/list-apps", async () => {
+          const res = await post("/api/list-apps", {
+            token: "tk-us-test",
+            target: SCALINGO_HOST,
+          });
+          await res.body?.cancel();
+        }],
+        ["/api/list-addons", async () => {
+          const res = await post("/api/list-addons", {
+            token: "tk-us-test",
+            app: "mon-app",
+            target: SCALINGO_HOST,
+          });
+          await res.body?.cancel();
+        }],
+        ["token d'addon", async () => {
+          await assertRejects(() =>
+            fetchAddonToken("bearer-du-compte", SCALINGO_HOST, "a", "ad-1")
+          );
+        }],
+        ["echange de token", async () => {
+          Deno.env.set("SCALINGO_AUTH_URL", "https://auth.scalingo.com");
+          await assertRejects(() => exchangeToken("tk-us-test"));
+          Deno.env.delete("SCALINGO_AUTH_URL");
+        }],
+      ];
+
+      for (const [nom, appelant] of appelants) {
+        sorties = [];
+        await appelant();
+        assertEquals(
+          sorties,
+          [],
+          `${nom} a joint le reseau malgre une destination classee non publique`,
+        );
+      }
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-43.17 bis: TEMOIN, les memes appelants sortent bien quand la destination est publique",
+  fn: async () => {
+    setup();
+    try {
+      // Sans ce temoin, le recensement ci-dessus serait vert sur un stub de fetch mal
+      // branche, ou sur des routes qui echouent avant meme d'envisager de sortir.
+      _setResolverForTests((_h, kind) => Promise.resolve(kind === "A" ? ["93.184.216.34"] : []));
+      sorties = [];
+      const res = await post("/api/list-apps", { token: "tk-us-test", target: SCALINGO_HOST });
+      await res.body?.cancel();
+      assertNotEquals(sorties.length, 0, "aucune sortie observee sur une destination publique");
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name:
+    "AC-43.22 (registre v5): une valeur d'origine operateur echappe a la contrainte d'hote, pas au classement d'adresse",
+  fn: async () => {
+    setup();
+    try {
+      // Moitie vraie du critere : SCALINGO_API_URL vient de l'operateur, qui a deja le
+      // controle du processus. Elle n'a donc pas a etre un hote Scalingo.
+      Deno.env.set("SCALINGO_API_URL", "https://mock.operateur.example");
+      _setResolverForTests((_h, kind) => Promise.resolve(kind === "A" ? ["93.184.216.34"] : []));
+      globalThis.fetch = ((input: string | URL | Request) => {
+        sorties.push(input instanceof Request ? input.url : String(input));
+        return Promise.resolve(
+          new Response(JSON.stringify({ addon: { token: "addon-tok" } }), { status: 200 }),
+        );
+      }) as typeof globalThis.fetch;
+      sorties = [];
+      const token = await fetchAddonToken("bearer", "https://mock.operateur.example", "a", "ad-1");
+      assertEquals(typeof token, "string");
+      assertEquals(sorties.length, 1);
+
+      // Moitie que l'implementation refuse, et elle a raison : l'exemption porte sur la
+      // contrainte de domaine Scalingo, jamais sur la classification d'adresse. Une valeur
+      // d'operateur qui pointerait le reseau prive resterait une sortie non publique, et
+      // egressFetch est le seul point de sortie, sans derogation par provenance.
+      _setResolverForTests((_h, kind) => Promise.resolve(kind === "A" ? ["10.0.0.7"] : []));
+      sorties = [];
+      await assertRejects(
+        () => fetchAddonToken("bearer", "https://mock.operateur.example", "a", "ad-1"),
+        Error,
+        "Target host resolves to a non-public address",
+      );
+      assertEquals(sorties, []);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/openapi-body-limit.test.ts
+++ b/tests/testi/openapi-body-limit.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 
 import { app } from "../../src/main.ts";
+import { FGP_SOURCE_HEADER, FGP_SOURCE_PROXY } from "../../src/constants.ts";
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete"];
 
@@ -149,6 +150,46 @@ Deno.test({
         true,
         `plafond de corps monte hors /api/ sur ${mount.path}`,
       );
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+// --- AC-47.10 : la provenance est uniforme sur /api/*, pas seulement sur les codes
+// que les handlers estampillaient un par un ---
+
+Deno.test({
+  name: "AC-47.10: toute reponse d'une route /api/* porte X-FGP-Source: proxy",
+  fn: async () => {
+    const json = { "Content-Type": "application/json" };
+    const cases: [string, RequestInit][] = [
+      ["/api/salt", {}],
+      ["/api/openapi.json", {}],
+      ["/api/generate", { method: "POST", headers: json, body: "{}" }],
+      ["/api/decode", { method: "POST", headers: json, body: "{}" }],
+      ["/api/share/decode", {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify({ encoded: "x".repeat(9000) }),
+      }],
+      ["/api/list-apps", { method: "POST", headers: json, body: "{}" }],
+      ["/api/test-proxy", { method: "POST", headers: json, body: "{}" }],
+      ["/api/generate", {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify({ p: "x".repeat(70000) }),
+      }],
+    ];
+
+    for (const [path, init] of cases) {
+      const res = await app.request(path, init);
+      assertEquals(
+        res.headers.get(FGP_SOURCE_HEADER),
+        FGP_SOURCE_PROXY,
+        `${path} (${res.status}) ne porte pas la provenance`,
+      );
+      await res.body?.cancel();
     }
   },
   sanitizeOps: false,

--- a/tests/testi/proxy-body-read.test.ts
+++ b/tests/testi/proxy-body-read.test.ts
@@ -1,0 +1,114 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+import type { Scope } from "../../src/middleware/scopes.ts";
+
+const CLIENT_KEY = "body-read-test-key-0123456789abc";
+const SERVER_SALT = "body-read-salt";
+const DETAILED_MAX_KB = 8;
+
+const originalFetch = globalThis.fetch;
+
+function setup() {
+  _resetStoreForTests();
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  Deno.env.set("FGP_LOGS_ENABLED", "1");
+  Deno.env.set("FGP_LOGS_DETAILED_MAX_KB", String(DETAILED_MAX_KB));
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )) as typeof globalThis.fetch;
+}
+
+function teardown() {
+  globalThis.fetch = originalFetch;
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+  Deno.env.delete("FGP_LOGS_ENABLED");
+  Deno.env.delete("FGP_LOGS_DETAILED_MAX_KB");
+}
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+function makeBlob(scopes: Scope[]): Promise<string> {
+  return encryptBlob(
+    {
+      v: 3,
+      token: "tok",
+      target: "https://api.mock.local",
+      auth: "bearer",
+      scopes,
+      ttl: 3600,
+      createdAt: Math.floor(Date.now() / 1000),
+      logs: { enabled: true, detailed: true },
+    },
+    CLIENT_KEY,
+    SERVER_SALT,
+  );
+}
+
+async function poste(blob: string, octetsDeBourrage: number): Promise<number> {
+  const res = await createApp().request(`/${blob}/v1/items`, {
+    method: "POST",
+    headers: { "X-FGP-Key": CLIENT_KEY, "Content-Type": "application/json" },
+    body: JSON.stringify({ kind: "x", padding: "a".repeat(octetsDeBourrage) }),
+  });
+  await res.body?.cancel();
+  return res.status;
+}
+
+const AVEC_FILTRE: Scope[] = [{
+  methods: ["POST"],
+  pattern: "/v1/items",
+  bodyFilters: [{ objectPath: "kind", objectValue: [{ type: "any", value: "x" }] }],
+}];
+const SANS_FILTRE: Scope[] = ["POST:/v1/items"];
+
+Deno.test({
+  name: "AC-47.7: quand seule la capture detailed a besoin du corps, la lecture s'arrete plus tot",
+  fn: async () => {
+    setup();
+    try {
+      // Taille intermediaire : au-dessus du plafond de capture de 8 Ko, tres en dessous des
+      // 512 Ko de l'inspection. C'est la seule fenetre ou les deux plafonds se distinguent.
+      const INTERMEDIAIRE = 32 * 1024;
+
+      const detailedSeul = await makeBlob(SANS_FILTRE);
+      const avecFiltre = await makeBlob(AVEC_FILTRE);
+
+      // Lire 512 Ko pour n'en garder que 8 serait du gaspillage sur le chemin chaud : la
+      // lecture s'arrete peu apres le plafond de capture et la requete est refusee la.
+      assertEquals(
+        await poste(detailedSeul, INTERMEDIAIRE),
+        413,
+        "la capture detailed lit au-dela de son propre plafond",
+      );
+
+      // Meme corps, meme capture detailed, mais un body filter en plus : le besoin change,
+      // le plafond aussi, et la requete passe. Sans ce cas, un plafond global rabaisse a
+      // 8 Ko rendrait l'assertion precedente verte tout en cassant l'inspection des corps.
+      assertEquals(
+        await poste(avecFiltre, INTERMEDIAIRE),
+        200,
+        "un body filter doit pouvoir inspecter bien au-dela du plafond de capture",
+      );
+
+      // Bornes de part et d'autre : sous le plafond de capture la requete passe, et le
+      // plafond d'inspection reste celui de l'ADR-0010 D7.
+      assertEquals(await poste(detailedSeul, 1024), 200);
+      assertEquals(await poste(avecFiltre, 1024 * 1024), 413);
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/proxy-headers-policy.test.ts
+++ b/tests/testi/proxy-headers-policy.test.ts
@@ -222,3 +222,19 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "AC-45.10 (registre v5): l'ordre des passes preserve l'Authorization issue du blob",
+  fn: async () => {
+    setup();
+    // Authorization est dans la denylist appliquee a l'appelant. Si cette passe tournait
+    // apres la pose des en-tetes d'auth, elle supprimerait celle du blob et le mode bearer
+    // partirait nu vers la cible : la requete serait refusee en amont sans que rien ici
+    // ne le voie, puisque le proxy est transparent. C'est la moitie observable du critere.
+    const h = await call({ "Authorization": "Bearer de-l-appelant" }, "bearer");
+    assertEquals(h.get("authorization"), "Bearer secret-du-blob");
+    teardown();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/proxy-prevalidation.test.ts
+++ b/tests/testi/proxy-prevalidation.test.ts
@@ -1,0 +1,179 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { Hono } from "hono";
+
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { _resetKeyCacheForTests } from "../../src/crypto/key-cache.ts";
+import { proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+
+const SERVER_SALT = "prevalidation-test-salt";
+const originalFetch = globalThis.fetch;
+const originalDeriveKey = crypto.subtle.deriveKey.bind(crypto.subtle);
+
+let derivations = 0;
+
+function setup() {
+  _resetStoreForTests();
+  _resetKeyCacheForTests();
+  derivations = 0;
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )) as typeof globalThis.fetch;
+  // Espion de comptage nomme par l'ADR-0010 D8. Il porte sur crypto.subtle.deriveKey et
+  // non sur le wrapper de src/crypto/blob.ts : c'est le PBKDF2 lui-meme qui coute 11,60 ms,
+  // et c'est donc lui qu'il faut voir ne pas se declencher.
+  // deno-lint-ignore no-explicit-any
+  (crypto.subtle as any).deriveKey = (...args: unknown[]) => {
+    derivations++;
+    // deno-lint-ignore no-explicit-any
+    return (originalDeriveKey as any)(...args);
+  };
+}
+
+function teardown() {
+  // deno-lint-ignore no-explicit-any
+  (crypto.subtle as any).deriveKey = originalDeriveKey;
+  globalThis.fetch = originalFetch;
+  _resetKeyCacheForTests();
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+}
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+function makeBlob(clientKey: string): Promise<string> {
+  return encryptBlob(
+    {
+      v: 2,
+      token: "tok",
+      target: "https://api.mock.local",
+      auth: "bearer",
+      scopes: ["*:*"],
+      ttl: 3600,
+      createdAt: Math.floor(Date.now() / 1000),
+    },
+    clientKey,
+    SERVER_SALT,
+  );
+}
+
+async function call(blob: string, clientKey: string): Promise<Response> {
+  return await createApp().request(`/${blob}/v1/items`, {
+    headers: { "X-FGP-Key": clientKey },
+  });
+}
+
+Deno.test({
+  name: "AC-50.7: une cle hors format est refusee avant toute derivation",
+  fn: async () => {
+    setup();
+    try {
+      // Blob reel et de taille nominale : le seul motif de refus disponible est la cle,
+      // sans quoi le plancher structurel d'AC-50.8 produirait le meme 401 pour une autre
+      // raison et le test resterait vert sur une pre-validation de cle supprimee.
+      const blob = await makeBlob("cle-de-reference-pour-la-forge-01");
+      assertNotEquals(blob.length < 64, true, "le blob temoin doit passer le plancher");
+
+      for (const badKey of ["court", "cle avec une espace dedans 0123456789"]) {
+        derivations = 0;
+        const res = await call(blob, badKey);
+        assertEquals(res.status, 401, `statut inattendu pour la cle ${JSON.stringify(badKey)}`);
+        assertEquals((await res.json()).error, "invalid_credentials");
+        assertEquals(res.headers.get("X-FGP-Source"), "proxy");
+        assertEquals(
+          derivations,
+          0,
+          `PBKDF2 execute ${derivations} fois sur une cle hors format`,
+        );
+      }
+
+      // Temoin de cablage : sans lui, un espion mal branche ou une route jamais atteinte
+      // ferait passer les assertions ci-dessus pour une bonne nouvelle.
+      // La forge du blob temoin a peuple le cache de derivation : sans cette purge, le
+      // temoin verifierait un hit de cache au lieu d'un PBKDF2.
+      _resetKeyCacheForTests();
+      derivations = 0;
+      const ok = await call(blob, "cle-de-reference-pour-la-forge-01");
+      await ok.body?.cancel();
+      assertEquals(ok.status, 200);
+      assertEquals(derivations, 1, "l'espion ne voit pas la derivation du cas nominal");
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-50.8: un blob sous le plancher structurel est refuse avant toute derivation",
+  fn: async () => {
+    setup();
+    try {
+      const clientKey = "cle-bien-formee-pour-le-plancher-01";
+
+      // 63 caracteres base64url valent 47 octets : sous l'IV de 12, le tag GCM de 16 et un
+      // flux gzip minimal. Ce blob ne peut rien contenir, le dechiffrer serait payer 11,60 ms
+      // pour un echec certain.
+      const tooShort = "a".repeat(63);
+      assertEquals(tooShort.length < 64, true);
+
+      derivations = 0;
+      const res = await call(tooShort, clientKey);
+      assertEquals(res.status, 401);
+      assertEquals((await res.json()).error, "invalid_credentials");
+      assertEquals(res.headers.get("X-FGP-Source"), "proxy");
+      assertEquals(derivations, 0, `PBKDF2 execute ${derivations} fois sur un blob trop court`);
+
+      // Meme cle, meme absence de contenu exploitable, mais au-dessus du plancher : la
+      // derivation a lieu. C'est ce qui prouve que le refus ci-dessus vient bien de la
+      // taille et pas d'un rejet en amont de la pre-validation.
+      derivations = 0;
+      const longEnough = "a".repeat(64);
+      const res2 = await call(longEnough, clientKey);
+      assertEquals(res2.status, 401);
+      assertEquals((await res2.json()).error, "invalid_credentials");
+      assertEquals(derivations, 1, "un blob au-dessus du plancher doit payer la derivation");
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-50.9: une cle bien formee paie la derivation, la pre-validation n'est pas une defense",
+  fn: async () => {
+    setup();
+    try {
+      // Non-propriete d'AC-50.9, ecrite pour qu'on ne vende jamais la pre-validation comme
+      // une limitation de debit : des cles de 24 caracteres bien formees et toutes
+      // differentes ratent le cache a 100 % et paient chacune leur PBKDF2.
+      const blob = await makeBlob("cle-de-reference-pour-la-forge-01");
+      const attempts = 5;
+      derivations = 0;
+      for (let i = 0; i < attempts; i++) {
+        const res = await call(blob, `cle-aleatoire-bien-formee-${String(i).padStart(6, "0")}`);
+        await res.body?.cancel();
+        assertEquals(res.status, 401);
+      }
+      assertEquals(
+        derivations,
+        attempts,
+        "la pre-validation ne doit filtrer que les sondes malformees",
+      );
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/purge-timer.test.ts
+++ b/tests/testi/purge-timer.test.ts
@@ -1,0 +1,59 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+
+import { capturedIntervals, restoreSetInterval } from "./_capture-intervals.ts";
+// Le suffixe fait une cle de module distincte : src/main.ts est deja evalue par les autres
+// fichiers de test du meme processus, et sans lui son setInterval ne se rejouerait pas.
+import "../../src/main.ts?purge-timer";
+import { deriveKey } from "../../src/crypto/blob.ts";
+import {
+  _keyCacheSizeForTests,
+  _resetKeyCacheForTests,
+  setCachedKey,
+} from "../../src/crypto/key-cache.ts";
+import { logsEnabled } from "../../src/logs/config.ts";
+
+restoreSetInterval();
+
+const TICK_MS = 60_000;
+
+Deno.test({
+  name: "AC-50.10: le timer de purge n'est pas conditionne a la feature logs",
+  fn: async () => {
+    Deno.env.delete("FGP_LOGS_ENABLED");
+
+    const timers = capturedIntervals.filter((t) => t.delay === TICK_MS);
+    assertNotEquals(
+      timers.length,
+      0,
+      `aucun timer a ${TICK_MS} ms enregistre au chargement, le test ne verifie plus rien`,
+    );
+
+    // Le kill switch est bien a l'arret : sans cette assertion le test resterait vert sur
+    // l'ancien comportement, ou la purge du cache vivait sous un if (logsEnabled()).
+    assertEquals(logsEnabled(), false, "FGP_LOGS_ENABLED doit etre a l'arret pour ce test");
+
+    const key = await deriveKey("cle-pour-le-timer-de-purge-01234", "purge-timer-salt");
+    const origNow = Date.now;
+    try {
+      // Entree fraiche : le timer n'y touche pas. C'est ce qui distingue une purge d'un
+      // vidage aveugle, lequel rendrait l'assertion suivante sans valeur.
+      _resetKeyCacheForTests();
+      setCachedKey("index-frais", key);
+      for (const timer of timers) timer.cb();
+      assertEquals(_keyCacheSizeForTests(), 1, "une entree fraiche a ete purgee a tort");
+
+      Date.now = () => origNow() + 11 * 60 * 1000;
+      for (const timer of timers) timer.cb();
+      assertEquals(
+        _keyCacheSizeForTests(),
+        0,
+        "l'entree expiree survit au timer alors que les logs sont a l'arret",
+      );
+    } finally {
+      Date.now = origNow;
+      _resetKeyCacheForTests();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/scope-verdict-parity.test.ts
+++ b/tests/testi/scope-verdict-parity.test.ts
@@ -1,0 +1,221 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { Hono } from "hono";
+
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import { proxyMiddleware } from "../../src/middleware/proxy.ts";
+import { checkRequestAccess, type Scope } from "../../src/middleware/scopes.ts";
+import { _resetStoreForTests } from "../../src/auth/cache.ts";
+
+const CLIENT_KEY = "verdict-parity-test-key-0123456789";
+const SERVER_SALT = "verdict-parity-salt";
+const originalFetch = globalThis.fetch;
+
+function setup() {
+  _resetStoreForTests();
+  Deno.env.set("FGP_SALT", SERVER_SALT);
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )) as typeof globalThis.fetch;
+}
+
+function teardown() {
+  globalThis.fetch = originalFetch;
+  Deno.env.delete("FGP_SALT");
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+}
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("/:blob{.+}/*", proxyMiddleware());
+  return app;
+}
+
+function makeBlob(scopes: Scope[], v = 5): Promise<string> {
+  return encryptBlob(
+    {
+      v,
+      token: "tok",
+      target: "https://api.mock.local",
+      auth: "bearer",
+      scopes,
+      ttl: 3600,
+      createdAt: Math.floor(Date.now() / 1000),
+    },
+    CLIENT_KEY,
+    SERVER_SALT,
+  );
+}
+
+async function proxyAllows(scopes: Scope[], method: string, pathWithQuery: string): Promise<
+  boolean
+> {
+  const blob = await makeBlob(scopes);
+  const res = await createApp().request(`/${blob}${pathWithQuery}`, {
+    method,
+    headers: { "X-FGP-Key": CLIENT_KEY },
+  });
+  await res.body?.cancel();
+  if (res.status === 200) return true;
+  assertEquals(res.status, 403, `statut inattendu ${res.status} pour ${method} ${pathWithQuery}`);
+  return false;
+}
+
+interface Cas {
+  titre: string;
+  scopes: Scope[];
+  method: string;
+  path: string;
+  attendu: boolean;
+}
+
+const PLAIN: Scope[] = ["GET:/v1/items"];
+const WILDCARD: Scope[] = ["GET:/v1/public/*"];
+const GITLAB: Scope[] = ["GET:/api/v4/projects/*"];
+const QUERY_FILTERED: Scope[] = [{
+  methods: ["GET"],
+  pattern: "/v1/orders",
+  queryFilters: [{ param: "status", values: [{ type: "any", value: "open" }] }],
+}];
+
+const CORPUS: Cas[] = [
+  // Le cas fondateur de l'ADR-0009 §4 : avant le lot de securite, le testeur repondait
+  // « refuse » la ou la production repondait 200, parce qu'il comparait le chemin query
+  // comprise. Un outil de verification qui se trompe dans le sens permissif est pire que
+  // pas d'outil, et c'est ce cas qui le revele.
+  { titre: "query non contrainte", scopes: PLAIN, method: "GET", path: "/v1/items", attendu: true },
+  {
+    titre: "query non contrainte, parametres arbitraires",
+    scopes: PLAIN,
+    method: "GET",
+    path: "/v1/items?action=delete&scope=all",
+    attendu: true,
+  },
+  {
+    titre: "methode hors scope",
+    scopes: PLAIN,
+    method: "POST",
+    path: "/v1/items",
+    attendu: false,
+  },
+  {
+    titre: "traversee percent-encodee",
+    scopes: WILDCARD,
+    method: "GET",
+    path: "/v1/public/..%2f..%2fadmin",
+    attendu: false,
+  },
+  {
+    titre: "wildcard nominal",
+    scopes: WILDCARD,
+    method: "GET",
+    path: "/v1/public/rapport.json",
+    attendu: true,
+  },
+  {
+    titre: "cas GitLab, slash encode dans un identifiant",
+    scopes: GITLAB,
+    method: "GET",
+    path: "/api/v4/projects/groupe%2Fprojet",
+    attendu: true,
+  },
+  {
+    titre: "query contrainte, valeur declaree",
+    scopes: QUERY_FILTERED,
+    method: "GET",
+    path: "/v1/orders?status=open",
+    attendu: true,
+  },
+  {
+    titre: "query contrainte, parametre non declare",
+    scopes: QUERY_FILTERED,
+    method: "GET",
+    path: "/v1/orders?status=open&debug=1",
+    attendu: false,
+  },
+];
+
+Deno.test({
+  name: "AC-46.2: PARITE, le testeur de scopes et le proxy rendent le meme verdict",
+  fn: async () => {
+    setup();
+    try {
+      for (const cas of CORPUS) {
+        // checkRequestAccess est la fonction que le testeur de l'UI appelle : la comparer a
+        // la reponse du proxy, c'est comparer les deux verdicts que l'utilisateur voit.
+        const testeur = checkRequestAccess(cas.scopes, cas.method, cas.path).allowed;
+        const proxy = await proxyAllows(cas.scopes, cas.method, cas.path);
+
+        // Les trois valeurs, pas deux : comparer le testeur au proxy seuls resterait vert
+        // si les deux basculaient ensemble sur une lecture des scopes commune mais fausse.
+        assertEquals(testeur, cas.attendu, `testeur, ${cas.titre}`);
+        assertEquals(proxy, cas.attendu, `proxy, ${cas.titre}`);
+      }
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-49.3 (registre v5): le verdict du testeur se calcule sans aucun appel reseau",
+  fn: () => {
+    let appels = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = ((input: string | URL | Request) => {
+      appels++;
+      throw new Error(`appel reseau interdit vers ${String(input)}`);
+    }) as typeof globalThis.fetch;
+    try {
+      for (const cas of CORPUS) {
+        assertEquals(
+          checkRequestAccess(cas.scopes, cas.method, cas.path).allowed,
+          cas.attendu,
+          cas.titre,
+        );
+      }
+      // C'est ce qui rend la route serveur de test de scope inutile : maintenir une copie
+      // serveur d'une logique deja executee dans le navigateur, c'est payer une surface
+      // publique non authentifiee pour zero valeur.
+      assertEquals(appels, 0, `${appels} appels reseau emis par l'evaluation du verdict`);
+    } finally {
+      globalThis.fetch = original;
+    }
+  },
+});
+
+Deno.test({
+  name: "AC-46.4 (registre v5): un pattern portant un ? reste dechiffrable et ne matche jamais",
+  fn: async () => {
+    setup();
+    try {
+      // Blob forge hors ligne, ce que la generation refuse (AC-46.3) : c'est exactement la
+      // population des blobs deja en circulation avant ce refus.
+      const scopes: Scope[] = ["GET:/v1/items?safe=1", "GET:/v1/orders"];
+      const blob = await makeBlob(scopes, 2);
+
+      // Le blob est accepte : refuser casserait /v1/orders pour un gain nul, un pattern qui
+      // ne peut rien autoriser n'est pas dangereux (ADR-0006 applique a la validation).
+      assertEquals(await proxyAllows(scopes, "GET", "/v1/orders"), true, "scope voisin casse");
+
+      assertNotEquals(blob.length, 0);
+
+      // Le pattern mort ne matche rien, ni sa forme litterale ni la ressource qu'il avait
+      // l'air de designer.
+      for (const chemin of ["/v1/items", "/v1/items?safe=1", "/v1/items%3Fsafe=1"]) {
+        assertEquals(
+          await proxyAllows(scopes, "GET", chemin),
+          false,
+          `le pattern mort a autorise ${chemin}`,
+        );
+      }
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testu/crypto/blob-validation.test.ts
+++ b/tests/testu/crypto/blob-validation.test.ts
@@ -742,3 +742,75 @@ Deno.test("AC-48.15: une regex hors dialecte est refusee avec un code dedie", as
   assertEquals(err instanceof BlobPolicyError, true);
   assertEquals((err as BlobPolicyError).code, "unsupported_regex");
 });
+
+function regex(value = "^a$") {
+  return { type: "regex", value };
+}
+
+async function refuseAuDechiffrement(v: number, scopes: unknown[], titre: string): Promise<void> {
+  const blob = await encryptRaw(makeConfig({ v, scopes: scopes as never }));
+  await assertRejects(
+    () => decryptBlob(blob, CLIENT_KEY, SERVER_SALT),
+    Error,
+    "malformed BlobConfig",
+    titre,
+  );
+}
+
+Deno.test("AC-48.15 (registre v5): les budgets sont globaux au blob, pas par filtre ni par portee", async () => {
+  // Cinq regex reparties sur deux filtres d'un meme scope. Un plafond par filtre les
+  // verrait comme trois puis deux et laisserait passer, ce qui laisserait la structure
+  // multiplicative intacte : c'est le comptage global qui borne le cout d'une requete.
+  const deuxFiltres = [{
+    methods: ["POST"],
+    pattern: "/v1/x",
+    bodyFilters: [
+      { objectPath: "a", objectValue: [regex(), regex(), regex()] },
+      { objectPath: "b", objectValue: [regex(), regex()] },
+    ],
+  }];
+  await refuseAuDechiffrement(3, deuxFiltres, "cinq regex sur deux filtres");
+
+  // Cinq regex reparties sur deux scopes distincts. Un plafond par portee compterait deux
+  // fois trois et deux, jamais cinq.
+  const deuxScopes = [
+    {
+      methods: ["POST"],
+      pattern: "/v1/x",
+      bodyFilters: [{ objectPath: "a", objectValue: [regex(), regex(), regex()] }],
+    },
+    {
+      methods: ["POST"],
+      pattern: "/v1/y",
+      bodyFilters: [{ objectPath: "b", objectValue: [regex(), regex()] }],
+    },
+  ];
+  await refuseAuDechiffrement(3, deuxScopes, "cinq regex sur deux scopes");
+
+  // Cinq regex reparties sur les deux axes que la v5 met en presence, un body filter et un
+  // query filter : le budget ne se remet pas a zero en changeant d'axe.
+  const deuxAxes = [{
+    methods: ["POST"],
+    pattern: "/v1/x",
+    bodyFilters: [{ objectPath: "a", objectValue: [regex(), regex(), regex()] }],
+    queryFilters: [{ param: "q", values: [regex(), regex()] }],
+  }];
+  await refuseAuDechiffrement(5, deuxAxes, "cinq regex sur deux axes");
+
+  // Temoin a quatre : le refus vient bien du total et pas de la repartition elle-meme,
+  // sans quoi les trois assertions ci-dessus passeraient pour de mauvaises raisons.
+  const quatreReparties = [
+    {
+      methods: ["POST"],
+      pattern: "/v1/x",
+      bodyFilters: [{ objectPath: "a", objectValue: [regex(), regex()] }],
+    },
+    {
+      methods: ["POST"],
+      pattern: "/v1/y",
+      bodyFilters: [{ objectPath: "b", objectValue: [regex(), regex()] }],
+    },
+  ];
+  const ok = await encryptRaw(makeConfig({ v: 3, scopes: quatreReparties as never }));
+  assertEquals((await decryptBlob(ok, CLIENT_KEY, SERVER_SALT)).v, 3);
+});

--- a/tests/testu/crypto/key-cache.test.ts
+++ b/tests/testu/crypto/key-cache.test.ts
@@ -8,7 +8,7 @@ import {
   purgeExpiredKeys,
   setCachedKey,
 } from "../../../src/crypto/key-cache.ts";
-import { deriveKey } from "../../../src/crypto/blob.ts";
+import { decryptBlob, deriveKey, encryptBlob } from "../../../src/crypto/blob.ts";
 
 const SALT = "key-cache-test-salt";
 
@@ -76,6 +76,99 @@ Deno.test("AC-50.4: une entree expiree est purgee et redérivee", async () => {
     assertEquals(_keyCacheSizeForTests(), 0);
   } finally {
     Date.now = origNow;
+    _resetKeyCacheForTests();
+  }
+});
+
+Deno.test("AC-50.5 (registre v5): le cache n'est jamais une dependance de correction", async () => {
+  const clientKey = "cle-pour-la-correction-0123456789";
+  const salt = "salt-correction";
+  const blob = await encryptBlob(
+    {
+      v: 2,
+      token: "tok",
+      target: "https://api.example.com",
+      auth: "bearer",
+      scopes: ["GET:/v1/items"],
+      ttl: 3600,
+      createdAt: 1_700_000_000,
+    },
+    clientKey,
+    salt,
+  );
+
+  // Cache vide, cache chaud, cache purge entre deux lectures : les trois rendent exactement
+  // la meme configuration. Sur Deno Deploy le cache est par isolate et ephemere, un produit
+  // dont la correction en dependrait serait faux une requete sur deux.
+  _resetKeyCacheForTests();
+  const froid = await decryptBlob(blob, clientKey, salt);
+
+  // Un voisin dans la table avant la relecture : sans lui, un index de cache degenere
+  // (constante, collision) rendrait quand meme la bonne cle et le test ne verrait rien.
+  await deriveKey("cle-voisine-dans-la-table-0123456", salt);
+  const chaud = await decryptBlob(blob, clientKey, salt);
+  assertEquals(_keyCacheSizeForTests() > 1, true, "le cache doit porter les deux entrees");
+
+  _resetKeyCacheForTests();
+  const apresPurge = await decryptBlob(blob, clientKey, salt);
+
+  assertEquals(chaud, froid);
+  assertEquals(apresPurge, froid);
+});
+
+Deno.test("AC-50.6: le trafic legitime rate le cache une fois, le trafic a cles aleatoires a 100 %", async () => {
+  _resetKeyCacheForTests();
+  const original = crypto.subtle.deriveKey.bind(crypto.subtle);
+  let calls = 0;
+  // deno-lint-ignore no-explicit-any
+  (crypto.subtle as any).deriveKey = (...args: unknown[]) => {
+    calls++;
+    // deno-lint-ignore no-explicit-any
+    return (original as any)(...args);
+  };
+  try {
+    const tours = 6;
+
+    calls = 0;
+    for (let i = 0; i < tours; i++) await deriveKey("cle-legitime-reutilisee-0123456789", SALT);
+    assertEquals(calls, 1, "le trafic legitime ne doit deriver qu'une fois");
+
+    // Le cache ne deplace pas le plafond de l'attaquant. Ce critere existe pour qu'on ne le
+    // vende jamais comme une limitation de debit.
+    calls = 0;
+    for (let i = 0; i < tours; i++) {
+      await deriveKey(`cle-aleatoire-${String(i).padStart(20, "0")}`, SALT);
+    }
+    assertEquals(calls, tours, "des cles toutes differentes doivent rater le cache a 100 %");
+  } finally {
+    // deno-lint-ignore no-explicit-any
+    (crypto.subtle as any).deriveKey = original;
+    _resetKeyCacheForTests();
+  }
+});
+
+Deno.test("AC-50.11: le nombre d'iterations PBKDF2 vaut toujours 100 000", async () => {
+  _resetKeyCacheForTests();
+  const original = crypto.subtle.deriveKey.bind(crypto.subtle);
+  const parametres: { name?: string; iterations?: number; hash?: string }[] = [];
+  // deno-lint-ignore no-explicit-any
+  (crypto.subtle as any).deriveKey = (...args: unknown[]) => {
+    parametres.push(args[0] as { name?: string; iterations?: number; hash?: string });
+    // deno-lint-ignore no-explicit-any
+    return (original as any)(...args);
+  };
+  try {
+    await deriveKey("cle-pour-lire-les-parametres-0123", SALT);
+    assertEquals(parametres.length, 1, "aucune derivation observee, le test ne verifie rien");
+    // Le parametre n'est pas porte par le blob : le baisser invalide tous les blobs en
+    // circulation, et l'argument « la cle est a haute entropie » ne tient plus depuis le
+    // BYOK, qui accepte des cles de 24 caracteres.
+    assertEquals(parametres[0].name, "PBKDF2");
+    assertEquals(parametres[0].iterations, 100_000);
+    assertEquals(parametres[0].hash, "SHA-256");
+  } finally {
+    // deno-lint-ignore no-explicit-any
+    (crypto.subtle as any).deriveKey = original;
     _resetKeyCacheForTests();
   }
 });

--- a/tests/testu/middleware/scopes-path-encoding.test.ts
+++ b/tests/testu/middleware/scopes-path-encoding.test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "@std/assert";
-import { canonicalizePath, checkRequestAccess } from "../../../src/middleware/scopes.ts";
+import {
+  canonicalizePath,
+  checkAccess,
+  checkRequestAccess,
+  splitPathAndQuery,
+} from "../../../src/middleware/scopes.ts";
 
 Deno.test("AC-44.1: le percent-encoding ne contourne pas le scope", () => {
   const v = checkRequestAccess(["GET:/v1/public/*"], "GET", "/v1/public/..%2f..%2fadmin");
@@ -51,6 +56,63 @@ Deno.test("AC-44.7: un chemin sans encodage donne le meme verdict qu'avant", () 
   assertEquals(checkRequestAccess(["GET:/v1/apps/*"], "GET", "/v1/apps/my-app").allowed, true);
   assertEquals(checkRequestAccess(["GET:/v1/apps/*"], "POST", "/v1/apps/my-app").allowed, false);
   assertEquals(checkRequestAccess(["GET:/v1/apps/*"], "GET", "/v2/apps/my-app").allowed, false);
+});
+
+Deno.test("AC-44.10: la regle des deux formes est monotone, elle n'ouvre jamais un acces", () => {
+  // Corpus dont le verdict est connu sous le controle de la seule forme brute, que rend
+  // checkAccess. La propriete a proteger n'est pas la valeur d'un verdict mais le sens de
+  // l'ecart : ajouter une forme de verification ne peut que reduire l'ensemble autorise,
+  // quelle que soit la forme ajoutee plus tard.
+  const corpus: [string[], string, string][] = [
+    [["GET:/v1/public/*"], "GET", "/v1/public/rapport.json"],
+    [["GET:/v1/public/*"], "GET", "/v1/public/..%2f..%2fadmin"],
+    [["GET:/v1/public/*"], "GET", "/v1/public/..%5c..%5cadmin"],
+    [["GET:/v1/public/*"], "GET", "/v1/public/..%252f..%252fadmin"],
+    [["GET:/api/v4/projects/*"], "GET", "/api/v4/projects/groupe%2Fprojet"],
+    [["GET:/projects/groupe%2Fprojet"], "GET", "/projects/groupe%2Fprojet"],
+    [["*:*"], "GET", "/v1//items"],
+    [["*:*"], "GET", "/v1/./items"],
+    [["GET:/v1/items"], "GET", "/v1/items?action=delete"],
+    [["GET:/v1/items"], "POST", "/v1/items"],
+    [["GET:/v1/a/*"], "GET", "/v1/a/b/../../c"],
+  ];
+
+  let resserres = 0;
+  for (const [scopes, method, path] of corpus) {
+    // La query est retiree de la ligne de base : checkAccess compare le chemin tel quel, la
+    // laisser comparerait l'axe chemin a l'axe chemin plus query et l'ecart mesure ne serait
+    // plus celui de la regle des deux formes.
+    const formeBrute = checkAccess(scopes, method, splitPathAndQuery(path)[0]);
+    const deuxFormes = checkRequestAccess(scopes, method, path).allowed;
+    assertEquals(
+      formeBrute === false && deuxFormes === true,
+      false,
+      `la regle a ouvert un acces sur ${method} ${path}`,
+    );
+    if (formeBrute && !deuxFormes) resserres++;
+  }
+
+  // Sans au moins un resserrement, le corpus ne distinguerait pas la monotonie d'une
+  // regle qui ne fait rien : le test passerait sur un checkRequestAccess evide.
+  assertEquals(resserres > 0, true, "le corpus n'exerce aucun resserrement, il ne prouve rien");
+});
+
+Deno.test("AC-44.11: un scope en correspondance exacte avec du percent-encoding devient plus strict", () => {
+  // Cout ergonomique assume de la decision, documente pour que personne ne le prenne plus
+  // tard pour un bug : la forme canonique /projects/groupe/projet n'est pas couverte par un
+  // pattern sans wildcard, donc le scope ne matche plus sa propre ecriture.
+  const exact = ["GET:/projects/groupe%2Fprojet"];
+  assertEquals(checkAccess(exact, "GET", "/projects/groupe%2Fprojet"), true);
+  const v = checkRequestAccess(exact, "GET", "/projects/groupe%2Fprojet");
+  assertEquals(v.allowed, false);
+  assertEquals(v.denial?.axis, "path_encoded");
+
+  // Le contournement est le wildcard, et il reste ouvert : c'est la voie de sortie a
+  // donner a qui tombe dessus (AC-44.4).
+  assertEquals(
+    checkRequestAccess(["GET:/projects/*"], "GET", "/projects/groupe%2Fprojet").allowed,
+    true,
+  );
 });
 
 Deno.test("AC-46.1: la query n'est pas contrainte et le verdict le dit", () => {

--- a/tests/testu/net/egress-warning.test.ts
+++ b/tests/testu/net/egress-warning.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+// L'avertissement est a un coup par instance de module : une fois pose, le drapeau interne
+// ne se remet pas a zero. Deux cles de module distinctes donnent donc deux instances
+// neuves, une pour le cas actif et une pour le temoin, sans quoi l'ordre des fichiers de
+// test du processus deciderait du resultat.
+import { classifyLiteralHost as classifyActif } from "../../../src/net/egress.ts?warn-actif";
+import { classifyLiteralHost as classifyTemoin } from "../../../src/net/egress.ts?warn-temoin";
+
+function captureWarnings(fn: () => void): string[] {
+  const messages: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    messages.push(args.map(String).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return messages;
+}
+
+Deno.test("AC-43.21 (registre v5): FGP_EGRESS_ALLOW_PRIVATE actif est signale bruyamment", () => {
+  Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+  try {
+    const messages = captureWarnings(() => {
+      classifyActif("10.0.0.1");
+      classifyActif("192.168.0.1");
+    });
+
+    // Un seul avertissement pour deux controles : c'est un signal, pas un flot qui noierait
+    // les journaux et finirait filtre.
+    assertEquals(messages.length, 1, `avertissements emis : ${messages.length}`);
+    assertStringIncludes(messages[0], "FGP_EGRESS_ALLOW_PRIVATE");
+    // Le message doit dire ce qui tombe, pas seulement qu'une variable est posee : active
+    // en production, l'instance redevient la SSRF non authentifiee que l'ADR-0009 corrige.
+    assertStringIncludes(messages[0], "G1");
+  } finally {
+    Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+  }
+});
+
+Deno.test("AC-43.21 (registre v5) bis: sans la variable, aucune ligne n'est ecrite", () => {
+  Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+  const messages = captureWarnings(() => {
+    // Une destination refusee, pour que le silence ne vienne pas d'un chemin non emprunte.
+    assertEquals(classifyTemoin("10.0.0.1")?.code, "target_forbidden");
+  });
+  assertEquals(messages, []);
+});

--- a/tests/testu/net/egress.test.ts
+++ b/tests/testu/net/egress.test.ts
@@ -156,3 +156,35 @@ Deno.test("AC-43.8 buildUpstreamUrl : le chemin proxy ne peut pas etre avale", (
     "https://api.example.com/projects/groupe%2Fprojet",
   );
 });
+
+Deno.test("AC-44.12: l'URL sortante est construite par l'API URL, jamais par concatenation", () => {
+  const t = (raw: string) => {
+    const r = parseTargetUrl(raw);
+    if ("error" in r) throw new Error("target refuse : " + raw);
+    return r.url;
+  };
+
+  // Le point de ce critere n'est pas la forme nominale, deja couverte, mais le sort d'un
+  // chemin proxy qui porte les deux caracteres capables de scinder une URL. Par
+  // concatenation, target + "/v1/items?x=1#f" ferait de "x=1" une query et perdrait "f" :
+  // le chemin controle ne serait plus celui emis. Pose dans pathname, l'API URL les encode.
+  const url = buildUpstreamUrl(t("https://api.example.com/base"), "/v1/items?x=1#f", "?a=1");
+  assertEquals(url.pathname, "/base/v1/items%3Fx=1%23f");
+  assertEquals(url.search, "?a=1");
+  assertEquals(url.hash, "");
+  assertEquals(url.origin, "https://api.example.com");
+
+  // La query vient du parametre et de lui seul : celle du target est deja refusee a
+  // l'etape 1 (AC-43.3), et une query vide ne doit pas laisser trainer un « ? » nu.
+  assertEquals(
+    buildUpstreamUrl(t("https://api.example.com/base"), "/v1/items", "").toString(),
+    "https://api.example.com/base/v1/items",
+  );
+
+  // Chemin de base a slashes multiples : la normalisation porte sur le target, jamais sur
+  // le chemin proxy, qui reste octet pour octet celui qui a ete controle.
+  assertEquals(
+    buildUpstreamUrl(t("https://api.example.com/base///"), "/v1//items", "").pathname,
+    "/base/v1//items",
+  );
+});

--- a/tests/testu/ui/scope-verdict-bundle.test.ts
+++ b/tests/testu/ui/scope-verdict-bundle.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "@std/assert";
+
+// Le bundle navigateur est le seul endroit ou l'on peut constater ce que le testeur de
+// scopes execute reellement une fois livre : src/ui/client/test-scope.ts touche au DOM et
+// ne peut pas etre importe sous la config serveur qui type-checke les tests. Lu depuis
+// static/ comme AC-10.5 et la parite de copy : les taches de test tournent sur une
+// allow-list de lecture qui ne couvre que static, et l'elargir annulerait ce durcissement.
+// Ce fichier exige donc un deno task build:client prealable.
+const BUNDLE = await Deno.readTextFile("static/client.js");
+
+Deno.test("AC-46.6: STRUCTUREL, le navigateur embarque la lecture des scopes a deux formes", () => {
+  // decodeURIComponent n'apparait dans le graphe client que via canonicalizePath, appele
+  // par la seule checkRequestAccess. esbuild elague ce qui n'est pas atteignable depuis
+  // l'entree : sa presence atteste que le testeur appelle la fonction d'autorisation du
+  // proxy, et non checkAccess, qui ne controle qu'une seule forme du chemin.
+  //
+  // Le marqueur ne se choisit pas au hasard. « path_encoded », candidat evident, reste dans
+  // le bundle meme quand checkRequestAccess a disparu : il vit dans une table de rangs
+  // partagee avec checkAccess. Un test bati dessus serait vert sur le code vulnerable.
+  assertEquals(
+    BUNDLE.includes("decodeURIComponent"),
+    true,
+    "la canonicalisation du chemin a disparu du bundle : le testeur ne partage plus la " +
+      "lecture des scopes du proxy, et il peut de nouveau affirmer un verdict que la " +
+      "production n'applique pas",
+  );
+});
+
+Deno.test("AC-49.3 (registre v5) bis: le bundle n'appelle aucune route serveur pour un verdict de scope", () => {
+  // La troisieme lecture des scopes, le handler serveur, a ete supprimee (AC-49.1). Un
+  // appel a cette route depuis le navigateur signifierait qu'elle est revenue.
+  assertEquals(
+    BUNDLE.includes("/api/test-scope"),
+    false,
+    "le bundle reference /api/test-scope",
+  );
+  // /api/test-proxy demeure et reste la voie de migration (AC-49.4) : c'est un test de
+  // bout en bout declenche par un bouton, pas le calcul du verdict.
+  assertEquals(
+    BUNDLE.includes("/api/test-proxy"),
+    true,
+    "la voie de repli /api/test-proxy a disparu du bundle",
+  );
+});


### PR DESCRIPTION
Le lot de sécurité ADR-0009 / ADR-0010 passe de **20 trous de couverture à 0**, plus un partiel, sur 102 critères. 25 tests pour 19 critères, 802 à 828.

## Ce que le protocole de morsure a changé

Chaque test a été vérifié en retirant sa garde. Trois conclusions ont changé, ce qui justifie à lui seul de l'appliquer systématiquement plutôt que de le traiter comme une formalité.

**AC-46.6** vérifiait la présence de `path_encoded` dans le bundle client pour prouver que le navigateur embarque bien `checkRequestAccess`. En mutant le client pour passer par `checkAccess`, le marqueur **reste présent** : il vit dans une table de rangs partagée entre les deux fonctions. Le test validait donc exactement ce qu'il prétendait interdire. Marqueur remplacé par `decodeURIComponent`, qui tombe à zéro sous mutation.

**AC-50.7 et AC-50.8**, la pré-validation avant PBKDF2. Sans la garde, le refus reste un `401 invalid_credentials` identique, le déchiffrement échouant de toute façon. Seul le compteur de dérivations bouge. Un test sur le statut serait resté vert sur une instance payant 11,60 ms par sonde malformée.

**AC-45.10 et AC-48.15** sont chacun le seul de leur famille à tomber sous mutation : inverser l'ordre des passes d'en-têtes laisse les neuf autres tests AC-45 verts, rendre le budget de regex local à chaque filtre laisse AC-48.11 vert.

## Un doublon évité

AC-47.6, le `bodyLimit` jamais monté sur `*`, était listé comme trou mais se trouvait déjà couvert par le test de recensement des montages livré avec la déclaration du 413, sous un numéro qui en désigne un autre. Marqué couvert dans la table de correspondance plutôt que redoublé.

## Deux critères corrigés, pas le code

AC-43.22 prétendait que les valeurs d'origine opérateur échappent au classement d'adresse. Sondé : un `SCALINGO_AUTH_URL` privé est bien refusé, et c'est le bon choix, une dérogation par provenance dans `egressFetch` cesserait d'en faire un point de sortie unique. AC-43.21 disait « au démarrage » là où l'avertissement est écrit au premier contrôle de destination.

## Le correctif de provenance

En comblant AC-47.10, qui exige `X-FGP-Source` sur les codes de plafond, le testeur a trouvé que les 413 le portaient mais pas le 400 de `/api/share/decode`, et que le trou était bien plus large : **aucun 400 de validation des routes `/api/*` ne portait cet en-tête**, alors que les 401, 413 et 502 des mêmes routes le portaient.

Un consommateur ne pouvait donc pas s'y fier : l'absence de l'en-tête ne voulait rien dire, ni « réponse upstream », ni « pas une réponse FGP ».

Tout ce que servent ces routes est produit par FGP, y compris l'enveloppe que `/api/test-proxy` met autour d'une réponse upstream. La provenance y vaut donc toujours `proxy`, et elle est posée au montage plutôt que dans chaque handler, sinon la prochaine route naîtra avec le même trou. Test vérifié mordant.

## Ce qui reste

La série v5, AC-51 à AC-57, n'a pas été réauditée sous ce protocole : le relevé initial décrivait un contrat non encore implémenté, et `queryFilters` est livré depuis avec ses tests. C'est le prochain lot naturel, pas un trou connu.

La renumérotation des tests existants pour les aligner sur le registre reste hors périmètre, la table de correspondance de `docs/review/ac-coverage-v5.md` en est la spécification.

## Vérification

`deno task verify` vert, 828 tests, 0 échec.