### PR TITLE
test(qa): audit de morsure de la serie v5, et deblocage de la CI cassee par zod-openapi 1.6.3

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,7 @@
     "hono": "npm:hono@^4.13.5",
     "@hono/swagger-ui": "npm:@hono/swagger-ui@^0.6.1",
     "zod": "npm:zod@^4.5.4",
-    "@hono/zod-openapi": "npm:@hono/zod-openapi@^1.6.2",
+    "@hono/zod-openapi": "npm:@hono/zod-openapi@1.6.2",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/encoding": "jsr:@std/encoding@^1.0.11"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -6,7 +6,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.6": "1.0.9",
     "npm:@hono/swagger-ui@~0.6.1": "0.6.1_hono@4.13.5",
-    "npm:@hono/zod-openapi@^1.6.2": "1.6.2_hono@4.13.5_zod@4.5.4",
+    "npm:@hono/zod-openapi@1.6.2": "1.6.2_hono@4.13.5_zod@4.5.4",
     "npm:concurrently@*": "9.2.1",
     "npm:esbuild@*": "0.28.0",
     "npm:hono@^4.13.5": "4.13.5",
@@ -908,7 +908,7 @@
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/encoding@^1.0.11",
       "npm:@hono/swagger-ui@~0.6.1",
-      "npm:@hono/zod-openapi@^1.6.2",
+      "npm:@hono/zod-openapi@1.6.2",
       "npm:hono@^4.13.5",
       "npm:zod@^4.5.4"
     ]

--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -3952,7 +3952,9 @@ Afficher « autorise » a cote de « la query est contrainte par au moins un sco
 
 **Given** un blob dont le seul scope couvrant le chemin de test porte des `queryFilters`, et une requete de test conforme
 **When** le highlight s'execute
-**Then** la note affichee est celle d'AC-56.2, « la query est contrainte », et non celle du troisieme etat. Une note qui apparaitrait des qu'un scope non contraignant existe **ailleurs** dans le blob, sur un autre chemin, alarmerait sans raison et serait ignoree en deux jours
+**Then** la note affichee est celle d'AC-56.2, « la query est contrainte », et non celle du troisieme etat. Une note qui apparaitrait des qu'un scope **contraignant** existe ailleurs dans le blob, sur un autre chemin ou une autre methode, alarmerait sans raison et serait ignoree en deux jours
+
+Enonce corrige le 2026-09-05. La redaction initiale disait « des qu'un scope non contraignant existe ailleurs », ce qui rendait le critere auto-contradictoire : le troisieme etat se declenche quand le scope qui accorde ne contraint pas ET qu'un scope contraignant couvre la meme requete. C'est donc le second qui peut apparaitre a tort, jamais le premier. Le drapeau concerne est `queryConstrainedElsewhere`, et il doit rester faux quand le scope contraignant ne couvre ni ce chemin ni cette methode
 
 ### AC-56.10 En production, le refus reste generique
 

--- a/docs/review/ac-coverage-v5.md
+++ b/docs/review/ac-coverage-v5.md
@@ -4,7 +4,7 @@
 **Ref AC** : `docs/acceptance-criteria.md` v5.0, series AC-43 a AC-57
 **Ref sources** : `docs/adr/0009-politique-de-sortie-du-proxy.md`, `docs/adr/0010-politique-limites-ressources.md`, `docs/specs.md` §18
 **Ref challenge v5** : `docs/review/challenge-query-filters-v5.md`
-**Suite** : `deno task verify` vert, **827 tests passes, 0 echec**
+**Suite** : `deno task verify` vert, **844 tests passes, 0 echec** (827 au releve du lot de securite, 828 avant l'audit v5 du 2026-09-05)
 
 La matrice du lot v4 (`ac-coverage-v4.md`, series AC-34 a AC-42) garde sa valeur pour son propre perimetre et n'est pas reecrite : c'est le releve date d'un lot livre.
 
@@ -26,7 +26,7 @@ Le releve du 2026-09-04 comptait **20 trous sur 102** pour un lot de securite li
 | AC-50, derivation et cache | 11 | 11 | 0 | 0 |
 | **Total lot securite** | **102** | **101** | **1** | **0** |
 
-**La serie v5 (AC-51 a AC-57, 86 criteres) n'a pas ete reauditee dans cette passe.** Le releve du 2026-09-04 la donnait a 4 OK et 82 TROU, mais ce chiffre decrivait un contrat non encore implemente : `queryFilters` et le blob v5 ont depuis ete livres et merges, avec leurs tests. Reporter ce chiffre ici serait faux. Il demande son propre releve, sur le meme protocole que celui du lot de securite.
+**La serie v5 a ete auditee le 2026-09-05**, sur le meme protocole, et son releve est plus bas. Le chiffre du 2026-09-04 (4 OK, 82 TROU) decrivait un contrat non encore implemente et n'a pas ete reconduit.
 
 ## Methode, et pourquoi elle compte ici
 
@@ -139,10 +139,117 @@ Trois criteres ne se testent pas par la voie qu'on prendrait naturellement. Le c
 
 ---
 
+# Audit de morsure de la serie v5 (AC-51 a AC-57)
+
+**Date** : 2026-09-05. **Base** : `main`, commit `1e4d83f`, suite verte a 828 tests avant la passe, **844 apres**.
+
+## Ce qui a ete audite, et ce qui ne l'a pas ete
+
+Cet audit ne parcourt pas les 86 criteres. Il vise les tests qui gardent une propriete **dont la perte serait invisible autrement** : si la garde saute et que quelqu'un s'en apercoit par un autre chemin que ce test, la mutation n'apprend rien. Ont donc ete mutees, par ordre d'importance : le deni par defaut, la restriction de `any` aux chaines a toute profondeur, les deux paliers d'occurrences, le plancher de version par axe, les schemas stricts de generation, et l'absence de valeur de query dans l'entry `network`.
+
+**Les tests de copy sont hors perimetre** : `tests/testu/ui/query-filters-copy.test.ts` verifie la parite entre `docs/specs.md` §12.5 et le bundle. Une rupture s'y voit a l'oeil nu sur la page, la muter serait du travail pour du travail. La logique que ces messages decrivent, elle, a ete auditee (voir AC-56.9 bis plus bas).
+
+## Protocole
+
+Chaque garde est retiree ou inversee dans `src/`, la suite est relancee, `src/` est restaure depuis git. Une mutation qui ne fait tomber aucun test designe une propriete non gardee. Dix-neuf mutations ont ete passees ; `src/` n'a jamais ete modifie de facon durable et le diff final ne touche que `tests/` et `docs/`.
+
+### Les mutations qui ont mordu
+
+| Mutation | Garde retiree ou inversee | Tests tombes |
+|----------|---------------------------|--------------|
+| M1 | la phase `undeclared` de `decideParsedQuery` | 9, dont AC-51.5, AC-51.6, AC-52.14, AC-55.5/6/10 |
+| M2a | la restriction `any`-chaine au dechiffrement | AC-53.2, 53.4, 53.5, 53.6 bis |
+| M2b | la propagation de `queryScoped` sous `and` et `not` | AC-53.4, 53.5, 53.6 bis |
+| M2c | la meme restriction a la generation | AC-53.3 |
+| M2d | la restriction **inversee** (`!== "string"`) | 14, dont AC-53.1 |
+| M3a | le palier bas `regex` (tout plafonne a 64) | AC-52.3, 52.4, 52.5 |
+| M3b | le palier rendu **global au `ScopeEntry`** | AC-52.7, et lui seul |
+| M3c | le refus au-dela du plafond remplace par un troncage | AC-52.2, 52.3, 52.4, 52.6, 56.10 |
+| M3d | off-by-one, `>` devient `>=` | AC-52.1, 52.3, 52.7, 52.8 |
+| M4a | le refus d'un `v` sous-declare | AC-54.7 |
+| M4b | le plancher d'auth structuree redevient `v === 4` | AC-54.3, 54.8 |
+| M4c | `queryFilters: []` compte comme un axe present | AC-54.6 |
+| M5b | `.strict()` sur `ScopeEntrySchema` | AC-53.15 bis, 53.16 bis |
+| M5c | `queryFilters` accepte puis **efface** de la valeur parsee | 8, dont AC-53.15 et 53.16 |
+| M6a | la coupe au premier `=` dans `extractQueryParamNames` | 5 tests du fichier unit |
+| M10 | la memoisation de l'axe query entre les deux passes de chemin | AC-52.9 |
+| M11 | `required` devient vrai par defaut | AC-51.8, 51.14 |
+| M12 | `queryConstrained` cesse de regarder le scope qui accorde | AC-51.15 |
+
+Deux resultats meritent d'etre notes parce qu'ils repondent a une question explicite du cadrage.
+
+**La restriction de `any` attrape bien l'inversion, pas seulement l'absence de message.** M2d, qui rend la garde strictement inverse, fait tomber quatorze tests dont AC-53.1, le critere positif. Un test qui se serait contente d'asserter la presence du message de validation serait reste vert. M2b confirme separement que la propagation en profondeur est gardee pour elle-meme : elle fait tomber AC-53.4, 53.5 et 53.6 bis sans toucher AC-53.2.
+
+**Les schemas stricts gardent deux proprietes distinctes, et chacune a son test.** M5b (perte du `.strict()`) ne fait tomber que les deux `bis`, qui gardent le rejet d'une cle inconnue. M5c (la cle reste connue mais l'axe disparait de la valeur parsee) fait tomber AC-53.15 et AC-53.16, qui gardent la survie de `queryFilters` jusqu'au blob. Aucun des deux ne couvre l'autre, ce qui est la bonne configuration.
+
+## Les huit prises
+
+Huit mutations n'ont fait tomber **aucun test** sur les 828. Dans les huit cas la propriete est correctement implementee dans `src/` : ce sont des tests manquants ou qui visent a cote, pas des defauts du code. `src/` n'a pas ete touche.
+
+**1. La query entiere peut entrer dans le champ `path` de l'entry `network` (AC-57.1, AC-57.2).** C'est la prise la plus lourde. `captureNetwork` recoit `proxyPath` sans query ; lui faire recevoir `proxyPath + search` fait entrer valeurs comprises dans le ring buffer, qui vit **en clair** contrairement au body `detailed` chiffre avec la cle client. 828 tests verts sur cette fuite. Toute la serie AC-57 tenait sur `tests/testu/logs-query-names.test.ts`, qui exerce `extractQueryParamNames` en isolation : une fuite qui entre par un autre champ de l'entry lui echappe entierement, par construction. Le test livre serialise l'entry **complete** et y cherche les secrets, ce qui est la seule forme qui ferme la porte.
+
+**2. La memoisation de l'axe query peut fuir d'un `ScopeEntry` a l'autre (AC-51.15).** Remplacer `queryDecisions[i]` par `queryDecisions[0]` fait resservir le refus du premier scope contraint a tous les suivants : l'additivite tombe des que l'auteur declare deux scopes contraints sur le meme chemin, ce qui est l'usage normal de la feature. AC-51.15 ne l'attrape pas parce que sa fixture met un scope **string** en premier, et un scope string sort de la boucle avant que l'axe query soit atteint. Le test visait juste pour ce qu'il enonce, mais sa forme ne peut structurellement pas exercer le partage. `AC-51.15 bis` couvre les deux ordres entre deux `ScopeEntry`, `AC-51.15 ter` couvre l'ordre inverse de l'original.
+
+**3. Un `queryFilters: []` peut activer le deni par defaut (AC-54.6).** L'enonce dit « n'induit pas de bump **et ne contraint rien** ». Le test ne verifiait que la premiere moitie, la version. Retirer `filters.length === 0` de `scopeQueryFilters` transforme un tableau vide en axe present qui refuse tout parametre, et personne ne tombe. `AC-54.6 bis` couvre la moitie matching.
+
+**4. Le plancher de version n'est pas garde a la generation (AC-54.8).** AC-54.8 verifie le plancher au **dechiffrement**, sur des blobs forges par `encryptBlob`. Le `Math.max` de `POST /api/generate` n'etait couvert par rien sur le seul cas ou une echelle et un maximum divergent : deux axes a la fois. Remplacer le `Math.max` par une cascade emet un `v: 4` pour un blob a auth structuree **et** `queryFilters`, que `decryptBlob` refuse aussitot par la regle d'AC-54.7. Symptome mesure sous mutation : `{"error":"invalid_credentials","message":"Unable to decrypt blob"}`, c'est-a-dire un blob mort livre avec un bandeau vert et un 401 qui envoie son porteur verifier une cle qui est bonne. `AC-54.8 bis` ferme le cas.
+
+**5. Le plafond de noms captures n'existait pour personne (AC-57.4).** `MAX_QUERY_PARAM_NAMES` vaut 32 ; le retirer laisse une requete unique remplir le ring buffer dimensionne par `FGP_LOGS_BUFFER_NETWORK`. Une seconde mutation, `continue` remplace par `break`, sous-compte les occurrences d'un nom deja retenu qui reapparait au-dela du plafond, ce que le commentaire du code prend soin d'eviter et que rien ne verifiait. `AC-57.4` et `AC-57.4 bis` couvrent les deux.
+
+**6. Une requete sans query pouvait produire un nom vide (AC-57.7).** Le garde-fou `search.length === 0` n'etait teste par rien. Le remplacer par un retour `{ names: [""] }` fait apparaitre dans l'entry ce qui se lit comme un parametre au nom vide reellement envoye, cas que AC-55.10 traite par ailleurs comme un parametre a part entiere. Le diagnostic devient trompeur sur toutes les requetes sans query. `AC-57.7` ferme le cas.
+
+**7. Le rendu des noms de parametres dans `/logs` n'etait garde par rien (AC-57.6).** Aucun test ne lisait `static/logs-client.js`. Remplacer le `textContent` du rendu des noms par un `innerHTML` passe sans qu'un test bouge, alors que c'est le seul chemin d'injection ouvert par la decision de §14.6 : un nom de parametre est une chaine d'appelant qui traverse le serveur jusqu'au navigateur de l'auteur du blob. `AC-57.6` recense le bundle, `AC-57.6 bis` est son temoin, sans lequel le recensement resterait vert sur un bundle d'ou l'affichage aurait disparu.
+
+**8. Le troisieme etat pouvait se declencher a tort (AC-56.9 bis).** `queryConstrainedElsewhere` ne doit se lever que si un scope contraignant couvre reellement cette methode et ce chemin. Le forcer a `true` des qu'un scope contraignant existe ailleurs dans le blob ne fait tomber aucun test : la note alarmerait sur un chemin que rien ne contraint. AC-56.9 et AC-56.9 bis n'etaient couverts que du cote copy, qui verifie la presence des chaines et pas la condition qui les declenche. `AC-56.9 bis` couvre les trois formes de non-couverture (autre chemin, autre methode) plus un temoin positif.
+
+## Une garde qui tient, mais par un fil
+
+**Le deni par defaut de bout en bout tenait a un seul test, hors serie.** Faire recevoir a `checkRequestAccess` un chemin ampute de sa query, depuis `src/middleware/proxy.ts`, ne faisait tomber que `AC-46.2` de `tests/testi/scope-verdict-parity.test.ts`, ecrit pour le lot de securite. Aucun test de la serie v5 ne l'attrapait, et **AC-56.10 restait vert pour la mauvaise raison** : son unique filtre porte `required: true`, donc toute requete dont la query n'atteint pas le controle est refusee de toute facon, et le `403` attendu tombe sans rien prouver du deni par defaut. AC-56.10 fait correctement son travail sur ce qu'il enonce, la genericite du message, et il n'a pas ete modifie. `AC-51.5 bis` ajoute la garde manquante, avec un filtre **non requis** pour que la seule cause de refus possible soit le parametre non declare.
+
+## Releve de couverture de la serie v5
+
+| Serie | Criteres | OK | PARTIEL | TROU |
+|-------|----------|----|---------|------|
+| AC-51, semantique de l'axe query | 16 | 16 | 0 | 0 |
+| AC-52, paliers d'occurrences et budget | 14 | 14 | 0 | 0 |
+| AC-53, validation blob et generation | 18 | 18 | 0 | 0 |
+| AC-54, version et retro-compatibilite | 9 | 9 | 0 | 0 |
+| AC-55, analyse de la query | 10 | 10 | 0 | 0 |
+| AC-56, testeur et diagnostic | 11 | 11 | 0 | 0 |
+| AC-57, capture des noms de parametres | 8 | 8 | 0 | 0 |
+| **Total v5** | **86** | **86** | **0** | **0** |
+
+**Ce tableau dit la couverture, pas la morsure de chaque ligne.** La legende du lot de securite plus haut associe les deux parce que chaque test y avait ete ecrit sous mutation. Ici la serie preexistait : l'audit a mute les gardes du cadrage, pas les 86 criteres un par un. Un « OK » de ce tableau signifie donc qu'un test vert nomme le critere ; la morsure est etablie pour les criteres cites dans les deux tableaux de mutations ci-dessus, et presumee pour les autres. Les series les moins exercees par cet audit sont AC-55, dont seuls 55.5, 55.6, 55.8 et 55.10 sont tombes sous une mutation, et la partie budget d'AC-52 (52.10 a 52.13), qui mesure des temps et n'a pas ete mutee.
+
+Deux criteres sont couverts par des tests portant un autre numero, sans doublon ecrit : **AC-54.1** par les assertions de version d'`AC-53.15`, qui le nomme en commentaire, et **AC-56.8** par `AC-46.2` de `tests/testi/scope-verdict-parity.test.ts`, dont la couverture de l'axe query est etablie par sa chute sous M1 et M14.
+
+## Tests ajoutes ou corriges dans cette passe
+
+| Test | Fichier | Critere | Mutation qu'il ferme |
+|------|---------|---------|----------------------|
+| `AC-51.5 bis` | `tests/testi/query-filters.test.ts` | AC-51.5 | query hors controle de scopes |
+| `AC-51.15 bis` et `ter` | `tests/testu/middleware/query-filters.test.ts` | AC-51.15 | memoisation partagee entre scopes |
+| `AC-54.6 bis` | `tests/testu/middleware/query-filters.test.ts` | AC-54.6 | `queryFilters: []` traite comme un axe |
+| `AC-54.8 bis` | `tests/testi/query-filters.test.ts` | AC-54.8 | plancher de version a la generation |
+| `AC-56.9 bis` | `tests/testu/middleware/query-filters.test.ts` | AC-56.9 bis | troisieme etat declenche a tort |
+| `AC-57.1`, `57.2`, `57.3`, `57.7`, `57.8`, `57.8 bis` | `tests/testi/logs-query-capture.test.ts` | AC-57.1 a 57.3, 57.7, 57.8 | query dans le champ `path` |
+| `AC-57.4` et `AC-57.4 bis` | `tests/testu/logs-query-names.test.ts` | AC-57.4 | plafond de noms, et `break` au lieu de `continue` |
+| `AC-57.6` et `AC-57.6 bis` | `tests/testu/ui/logs-bundle.test.ts` | AC-57.6 | `innerHTML` dans le rendu des noms |
+
+`tests/testu/ui/logs-bundle.test.ts` lit `static/logs-client.js` et exige donc un `deno task build:client` prealable, comme `scope-verdict-bundle.test.ts` et la parite de copy.
+
+## Un critere corrige, il etait auto-contradictoire
+
+**AC-56.9 bis** disait que la note ne doit pas apparaitre « des qu'un scope **non** contraignant existe ailleurs dans le blob ». C'est l'inverse du mecanisme : le troisieme etat se declenche quand le scope qui accorde ne contraint pas **et** qu'un scope contraignant couvre la meme requete. Le drapeau qui peut se lever a tort est donc `queryConstrainedElsewhere`, qui compte les scopes **contraignants**. L'enonce est corrige dans `docs/acceptance-criteria.md` avec la trace de la correction, et le test livre porte la forme corrigee.
+
+---
+
 ## Ce que je n'ai pas couvert
 
-- **La serie v5, AC-51 a AC-57.** Elle demande son propre releve, sur le meme protocole. Le chiffre du 2026-09-04 est perime et n'a pas ete reconduit ici.
 - **La moitie 400 d'AC-47.10**, decrite plus haut : arbitrage, pas test.
+- **Les tests de copy de la serie v5**, hors perimetre de cet audit par decision explicite : `tests/testu/ui/query-filters-copy.test.ts` n'a pas ete mute. Sa logique sous-jacente l'a ete, et AC-56.9 bis en est sorti.
+- **La nomenclature de `tests/testu/logs-query-names.test.ts`.** Neuf des onze tests de ce fichier ne portent aucun numero d'AC, ce qui viole la convention de nommage. Ils couvrent AC-57.2 et AC-57.5 sous des libelles descriptifs. Je ne les ai pas renommes : c'est la meme tache mecanique que la renumerotation deja arbitree, et la faire au milieu d'un audit melangerait deux diffs. Les deux tests ajoutes portent leur numero.
+- **Le cout reel de la double passe de chemin sous mutation M10.** AC-52.9 mesure le nombre de lectures de `values`, ce qui suffit a detecter la perte de memoisation, mais ne mesure pas le temps. Le budget lui-meme reste couvert par AC-52.10 a AC-52.13.
 - **La passe finale de `stripTransportHeaders` sur les en-tetes hop-by-hop.** Elle ne retire que `Host` et `X-FGP-*`. Un `AuthSpec` qui tenterait de poser `TE` ou `Connection` n'atteint jamais cette passe : `validateHeaderName` refuse ces noms, et `isValidAuthSpec` est appele au dechiffrement, donc le blob forge est refuse en entier. La defense tient, mais par la validation et non par le strip, et aucun chemin public ne permet d'exercer le strip lui-meme. AC-45.10 est donc couvert sur sa moitie observable, l'ordre des passes, verifiee par inversion.
 - **Le rebinding DNS**, explicitement laisse ouvert par l'ADR-0009. Non testable en l'etat, ne figure dans aucun critere, vit en §13 comme non-garantie.
 - **La renumerotation des tests existants.** Arbitrage inchange : la table ci-dessus en est la specification, elle se traite en tache mecanique separee sur un arbre ou personne d'autre n'ecrit.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
-import { Hono, type MiddlewareHandler } from "hono";
+import { type ErrorHandler, Hono, type MiddlewareHandler } from "hono";
 import { serveStatic } from "hono/deno";
 import { logger } from "hono/logger";
 import { secureHeaders } from "hono/secure-headers";
 import { bodyLimit } from "hono/body-limit";
+import { HTTPException } from "hono/http-exception";
 
 import { blobHeaderProxy, proxyMiddleware } from "./middleware/proxy.ts";
 import { uiRoutes } from "./routes/ui.tsx";
@@ -112,15 +113,35 @@ function withProxyErrorSecurity(inner: MiddlewareHandler): MiddlewareHandler {
   };
 }
 
-app.onError((err, c) => {
-  console.error("[fgp] unhandled error:", err);
+// Le projet n'emet jamais d'HTTPException lui-meme, c'est une regle de CLAUDE.md. Mais une
+// dependance peut en lever une, et l'aplatir en 500 transforme un refus de contrat en panne
+// serveur : @hono/zod-openapi 1.6.3 leve un HTTPException 415 sur un Content-Type non JSON,
+// ce qui faisait repondre 500 a toutes les routes /api/* pour une requete simplement mal
+// formee. On honore donc le status porte, en gardant la shape {error, message} du produit.
+const HTTP_EXCEPTION_CODES: Record<number, string> = {
+  400: "invalid_body",
+  413: "payload_too_large",
+  415: "unsupported_media_type",
+};
+
+export const fgpErrorHandler: ErrorHandler = (err, c) => {
+  const status = err instanceof HTTPException ? err.status : 500;
+  const known = HTTP_EXCEPTION_CODES[status];
+
+  // Un 500 reste une anomalie a diagnostiquer, un refus de contrat n'en est pas une.
+  if (status === 500) console.error("[fgp] unhandled error:", err);
+
   const response = c.json(
-    { error: "internal_error", message: "Internal server error" },
-    500,
+    status === 500
+      ? { error: "internal_error", message: "Internal server error" }
+      : { error: known ?? "invalid_request", message: err.message },
+    status,
   );
   response.headers.set(FGP_SOURCE_HEADER, FGP_SOURCE_PROXY);
   return response;
-});
+};
+
+app.onError(fgpErrorHandler);
 
 app.use("*", logger());
 app.use("*", withProxyErrorSecurity(blobHeaderProxy()));

--- a/tests/testi/error-handler.test.ts
+++ b/tests/testi/error-handler.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import { fgpErrorHandler } from "../../src/main.ts";
+import { FGP_SOURCE_HEADER, FGP_SOURCE_PROXY } from "../../src/constants.ts";
+
+// Le projet ne leve jamais d'HTTPException lui-meme, c'est une regle de CLAUDE.md. Une
+// dependance le fait : @hono/zod-openapi 1.6.3 leve un 415 sur un Content-Type non JSON.
+// Aplatir ce refus de contrat en 500 faisait repondre « panne serveur » a une requete
+// simplement mal formee, sur toutes les routes /api/*.
+function probe(thrown: unknown): Hono {
+  const app = new Hono();
+  app.onError(fgpErrorHandler);
+  app.get("/boom", () => {
+    throw thrown;
+  });
+  return app;
+}
+
+Deno.test("AC-41.12: un HTTPException garde son status au lieu de devenir un 500", async () => {
+  const res = await probe(new HTTPException(415, { message: "Unsupported Media Type" }))
+    .request("/boom");
+
+  assertEquals(res.status, 415);
+  const body = await res.json();
+  assertEquals(body.error, "unsupported_media_type");
+  assertEquals(res.headers.get(FGP_SOURCE_HEADER), FGP_SOURCE_PROXY);
+});
+
+Deno.test("AC-41.12 bis: un status sans code connu reste nomme, pas internal_error", async () => {
+  const res = await probe(new HTTPException(418, { message: "teapot" })).request("/boom");
+
+  assertEquals(res.status, 418);
+  assertEquals((await res.json()).error, "invalid_request");
+});
+
+Deno.test("AC-41.12 ter: une erreur quelconque reste un 500 internal_error", async () => {
+  const res = await probe(new Error("boom")).request("/boom");
+
+  assertEquals(res.status, 500);
+  const body = await res.json();
+  assertEquals(body.error, "internal_error");
+  // Le message d'une erreur non prevue ne doit pas fuiter vers l'appelant.
+  assertEquals(body.message, "Internal server error");
+});
+
+Deno.test("AC-41.12 quater: un HTTPException 500 reste traite comme une anomalie", async () => {
+  const res = await probe(new HTTPException(500, { message: "detail interne" })).request("/boom");
+
+  assertEquals(res.status, 500);
+  assertEquals((await res.json()).message, "Internal server error");
+});

--- a/tests/testi/logs-query-capture.test.ts
+++ b/tests/testi/logs-query-capture.test.ts
@@ -1,0 +1,173 @@
+import { assertEquals } from "@std/assert";
+
+import { app } from "../../src/main.ts";
+import { encryptBlob } from "../../src/crypto/blob.ts";
+import type { BlobConfig } from "../../src/crypto/blob.ts";
+import { _getNetworkBufferForTests, _resetStoreForTests } from "../../src/logs/store.ts";
+import { computeBlobId } from "../../src/logs/blob-id.ts";
+
+const SALT = "logs-query-capture-salt";
+const CLIENT_KEY = "logs-query-capture-key-0123";
+const API_KEY = "sk-live-000000";
+const TOKEN = "abcdef";
+
+function makeBlob(overrides: Partial<BlobConfig> = {}): Promise<string> {
+  const config: BlobConfig = {
+    v: 2,
+    token: "tk-test",
+    target: "https://api.mock.local",
+    auth: "bearer",
+    scopes: ["GET:/v1/items"],
+    ttl: 3600,
+    createdAt: Math.floor(Date.now() / 1000),
+    ...overrides,
+  };
+  return encryptBlob(config, CLIENT_KEY, SALT);
+}
+
+const originalFetch = globalThis.fetch;
+
+// La capture n'est observable qu'a travers le proxy reel : les criteres AC-57.1 et AC-57.2
+// portent sur l'entry telle qu'elle atterrit dans le ring buffer, pas sur le retour de
+// extractQueryParamNames. Une fuite peut entrer par n'importe lequel des champs poses par
+// captureNetwork, et le « path » en est un.
+function proxied(fn: (ctx: { blob: string; blobId: string }) => Promise<void>, logsOn = true) {
+  return async () => {
+    Deno.env.set("FGP_SALT", SALT);
+    Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+    if (logsOn) Deno.env.set("FGP_LOGS_ENABLED", "1");
+    _resetStoreForTests();
+    globalThis.fetch = (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch;
+    try {
+      const blob = await makeBlob({ logs: { enabled: true, detailed: false } });
+      await fn({ blob, blobId: await computeBlobId(blob) });
+    } finally {
+      globalThis.fetch = originalFetch;
+      _resetStoreForTests();
+      Deno.env.delete("FGP_SALT");
+      Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+      Deno.env.delete("FGP_LOGS_ENABLED");
+    }
+  };
+}
+
+async function call(blob: string, pathWithQuery: string): Promise<void> {
+  const res = await app.request(`/${blob}${pathWithQuery}`, {
+    headers: { "X-FGP-Key": CLIENT_KEY },
+  });
+  await res.body?.cancel();
+}
+
+Deno.test({
+  name: "AC-57.1: les noms de parametres sont captures et le path reste sans query",
+  fn: proxied(async ({ blob, blobId }) => {
+    await call(blob, "/v1/items?status=open&per_page=50");
+
+    const buf = _getNetworkBufferForTests(blobId);
+    assertEquals(buf.length, 1);
+    assertEquals(buf[0].queryParamNames, ["status", "per_page"]);
+    // Le champ « path » decrit le chemin, pas la requete : §14.6 le veut inchange. Y laisser
+    // la query y ferait entrer les valeurs par la porte de service, sur la seule surface que
+    // rien ne chiffre.
+    assertEquals(buf[0].path, "/v1/items");
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-57.2: SECURITE, aucune valeur de parametre n'entre dans l'entry network",
+  fn: proxied(async ({ blob, blobId }) => {
+    await call(blob, `/v1/items?api_key=${API_KEY}&token=${TOKEN}&status=open`);
+
+    const buf = _getNetworkBufferForTests(blobId);
+    assertEquals(buf.length, 1);
+    assertEquals(buf[0].queryParamNames, ["api_key", "token", "status"]);
+    // Le recensement porte sur l'entry entiere et non sur un champ nomme : c'est ce qui
+    // distingue ce critere d'une assertion sur queryParamNames, qui resterait verte si la
+    // valeur entrait par « path » ou par une concatenation quelconque.
+    const serialized = JSON.stringify(buf[0]);
+    for (const secret of [API_KEY, TOKEN]) {
+      assertEquals(
+        serialized.includes(secret),
+        false,
+        `« ${secret} » a fuite dans l'entry network, qui vit en clair dans le ring buffer : ` +
+          serialized,
+      );
+    }
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-57.3: le comptage d'occurrences est diagnosticable sans les valeurs",
+  fn: proxied(async ({ blob, blobId }) => {
+    const ids = Array.from({ length: 5 }, (_, i) => `ids=v${i}`).join("&");
+    await call(blob, `/v1/items?${ids}&status=open`);
+
+    const buf = _getNetworkBufferForTests(blobId);
+    assertEquals(buf[0].queryParamNames, ["ids", "status"]);
+    // Un ensemble dedoublonne perdrait le « 5 », qui est la seule information capable
+    // d'expliquer a posteriori un refus par plafond d'occurrences (AC-52.2).
+    assertEquals(buf[0].queryParamRepeats, [["ids", 5]]);
+    assertEquals(JSON.stringify(buf[0]).includes("v3"), false);
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-57.7: aucune capture quand la requete n'a pas de query",
+  fn: proxied(async ({ blob, blobId }) => {
+    await call(blob, "/v1/items");
+
+    const buf = _getNetworkBufferForTests(blobId);
+    assertEquals(buf.length, 1);
+    // Le champ doit etre absent, jamais un tableau contenant la chaine vide : celle-ci se
+    // lirait comme un parametre au nom vide reellement envoye par l'appelant, cas que
+    // AC-55.10 traite comme un parametre a part entiere.
+    assertEquals(buf[0].queryParamNames, undefined);
+    assertEquals(buf[0].queryParamRepeats, undefined);
+    assertEquals(buf[0].queryParamNamesTruncated, undefined);
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-57.8: NON-REGRESSION, la capture des noms reste soumise au meme gating",
+  fn: proxied(async ({ blob, blobId }) => {
+    // Kill switch a l'arret : proxied ne l'a pas pose, la requete doit passer sans qu'aucune
+    // entry ne soit stockee, noms de parametres compris.
+    await call(blob, `/v1/items?api_key=${API_KEY}`);
+    assertEquals(_getNetworkBufferForTests(blobId).length, 0);
+  }, false),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-57.8 bis: un blob sans logs.enabled ne capture aucun nom de parametre",
+  fn: async () => {
+    Deno.env.set("FGP_SALT", SALT);
+    Deno.env.set("FGP_EGRESS_ALLOW_PRIVATE", "1");
+    Deno.env.set("FGP_LOGS_ENABLED", "1");
+    _resetStoreForTests();
+    globalThis.fetch = (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch;
+    try {
+      const blob = await makeBlob();
+      const blobId = await computeBlobId(blob);
+      await call(blob, `/v1/items?api_key=${API_KEY}`);
+      assertEquals(_getNetworkBufferForTests(blobId).length, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      _resetStoreForTests();
+      Deno.env.delete("FGP_SALT");
+      Deno.env.delete("FGP_EGRESS_ALLOW_PRIVATE");
+      Deno.env.delete("FGP_LOGS_ENABLED");
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/testi/query-filters.test.ts
+++ b/tests/testi/query-filters.test.ts
@@ -129,6 +129,39 @@ Deno.test({
 });
 
 Deno.test({
+  name: "AC-54.8 bis: le plancher de version s'applique aussi a la generation",
+  fn: isolated(async () => {
+    // AC-54.8 verifie le plancher au DECHIFFREMENT, sur des blobs forges par encryptBlob.
+    // La generation calcule « v » de son cote, et rien ne la couvrait sur le seul cas ou
+    // une echelle et un maximum divergent : deux axes a la fois. Un « v: 4 » emis ici
+    // produit un blob que decryptBlob refuse (AC-54.7), c'est-a-dire un blob mort livre
+    // a son auteur avec un bandeau vert.
+    const gen = await post("/api/generate", {
+      target: "https://api.mock.local",
+      auth: {
+        type: "headers",
+        headers: [
+          { name: "X-API-Key", value: "sk-live-000000" },
+          { name: "X-Client-Id", value: "acme" },
+        ],
+      },
+      scopes: [QUERY_SCOPE],
+      ttl: 3600,
+    });
+    assertEquals(gen.status, 200, await gen.clone().text());
+    const { blob, key } = await gen.json();
+
+    const dec = await post("/api/decode", { blob, key });
+    assertEquals(dec.status, 200, await dec.clone().text());
+    const decoded = await dec.json();
+    assertEquals(decoded.version, 5);
+    assertEquals(decoded.scopes[0].queryFilters.length, 1);
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
   name: "AC-53.15 bis: une cle inconnue dans un ScopeEntry est refusee, jamais strippee",
   fn: isolated(async () => {
     // Une cle mal orthographiee doit produire une erreur. Strippee en silence, elle
@@ -384,6 +417,40 @@ Deno.test({
     });
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("X-FGP-Source"), "upstream");
+    assertEquals(new URL(captured.url()).search, "?status=open");
+  }),
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-51.5 bis: integration, le deni par defaut refuse un parametre non declare",
+  fn: isolated(async () => {
+    const captured = captureFetch();
+    const app = createProxyApp();
+    // Le filtre n'est PAS « required » : c'est ce qui rend ce test discriminant. Avec un
+    // filtre requis, une requete est refusee des que la query n'atteint pas le controle de
+    // scopes, et le 403 ne prouve alors rien du deni par defaut. Ici, la seule cause de
+    // refus possible est « sort n'est pas declare ».
+    const blob = await makeBlob([{
+      methods: ["GET"],
+      pattern: "/v1/items",
+      queryFilters: [{ param: "status", values: [{ type: "any", value: "open" }] }],
+    } as unknown as Scope]);
+
+    const denied = await app.request(`/${blob}/v1/items?status=open&sort=asc`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+    assertEquals(denied.status, 403);
+    assertEquals((await denied.json()).error, "scope_denied");
+    // Aucun appel sortant : le refus precede la resolution de destination.
+    assertEquals(captured.url(), "");
+
+    // Temoin : la meme requete sans le parametre non declare traverse.
+    const ok = await app.request(`/${blob}/v1/items?status=open`, {
+      headers: { "X-FGP-Key": CLIENT_KEY },
+    });
+    assertEquals(ok.status, 200);
     assertEquals(new URL(captured.url()).search, "?status=open");
   }),
   sanitizeOps: false,

--- a/tests/testu/logs-query-names.test.ts
+++ b/tests/testu/logs-query-names.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals } from "@std/assert";
 
-import { extractQueryParamNames, MAX_QUERY_PARAM_NAME_LENGTH } from "../../src/logs/capture.ts";
+import {
+  extractQueryParamNames,
+  MAX_QUERY_PARAM_NAME_LENGTH,
+  MAX_QUERY_PARAM_NAMES,
+} from "../../src/logs/capture.ts";
 
 const SECRET = "sk-live-51H9xQ2eZvKYlo8";
 
@@ -49,6 +53,28 @@ Deno.test("§19.10 : un parametre sans « = » reste un nom, comme le meme avec 
   // ici ferait disparaitre du diagnostic la forme la plus courante des drapeaux (?force).
   assertEquals(names("?flag"), ["flag"]);
   assertEquals(names("?flag="), ["flag"]);
+});
+
+Deno.test("AC-57.4: le nombre de noms retenus est plafonne et la troncature est signalee", () => {
+  const search = "?" +
+    Array.from({ length: MAX_QUERY_PARAM_NAMES + 20 }, (_, i) => `p${i}=v`).join("&");
+  const extracted = extractQueryParamNames(search);
+  // Le ring buffer est dimensionne par FGP_LOGS_BUFFER_NETWORK : sans plafond, une requete
+  // unique en consomme la totalite et evince tout l'historique de diagnostic.
+  assertEquals(extracted?.names.length, MAX_QUERY_PARAM_NAMES);
+  assertEquals(extracted?.truncated, true);
+  assertEquals(extracted?.names[0], "p0");
+});
+
+Deno.test("AC-57.4 bis: le plafond n'interrompt pas le comptage d'un nom deja retenu", () => {
+  // Sortir de la boucle sur le plafond sous-compterait « ids » : ses occurrences tardives
+  // sont precisement ce qui explique un refus par plafond d'occurrences (AC-52.2).
+  const filler = Array.from({ length: MAX_QUERY_PARAM_NAMES + 5 }, (_, i) => `p${i}=v`);
+  const search = "?ids=a&" + filler.join("&") + "&ids=b&ids=c";
+  const extracted = extractQueryParamNames(search);
+  assertEquals(extracted?.names.length, MAX_QUERY_PARAM_NAMES);
+  assertEquals(extracted?.repeats, [["ids", 3]]);
+  assertEquals(extracted?.truncated, true);
 });
 
 Deno.test("le plafond de longueur s'applique apres la coupe, jamais avant", () => {

--- a/tests/testu/middleware/query-filters.test.ts
+++ b/tests/testu/middleware/query-filters.test.ts
@@ -179,6 +179,89 @@ Deno.test("AC-51.15: additivite, un scope non contraignant autorise malgre le sc
   assertEquals(v.queryConstrained, false);
 });
 
+Deno.test("AC-51.15 bis: additivite entre deux scopes contraints, dans les deux ordres", () => {
+  // AC-51.15 met un scope string en premier, et un scope string sort de la boucle avant que
+  // l'axe query soit atteint : cette forme ne peut pas exercer le partage des decisions de
+  // query entre scopes. Deux ScopeEntry contraints, si. Le refus du premier ne doit jamais
+  // etre resservi au second, sans quoi l'additivite tombe des que l'auteur declare deux
+  // scopes contraints sur le meme chemin, ce qui est le cas d'usage normal de la feature.
+  const byStatus = entry([{ param: "status", values: [{ type: "any", value: "open" }] }]);
+  const bySort = entry([{ param: "sort", values: [{ type: "any", value: "asc" }] }]);
+
+  for (
+    const [label, scopes] of [
+      ["contraignant d'abord", [byStatus, bySort]],
+      ["contraignant ensuite", [bySort, byStatus]],
+    ] as [string, Scope[]][]
+  ) {
+    const onSort = verdict(scopes, "/v1/items?sort=asc");
+    assertEquals(onSort.allowed, true, `${label} : ?sort=asc doit etre autorise`);
+    const onStatus = verdict(scopes, "/v1/items?status=open");
+    assertEquals(onStatus.allowed, true, `${label} : ?status=open doit etre autorise`);
+    // Et l'additivite n'ouvre rien : un parametre qu'aucun des deux ne declare reste refuse.
+    assertEquals(allowed(scopes, "/v1/items?force=true"), false, label);
+  }
+});
+
+Deno.test("AC-51.15 ter: additivite quand le scope contraignant precede le scope string", () => {
+  const scopes: Scope[] = [
+    entry([{ param: "status", values: [{ type: "any", value: "open" }] }]),
+    "GET:/v1/items",
+  ];
+  const v = verdict(scopes, "/v1/items?force=true");
+  assertEquals(v.allowed, true);
+  assertEquals(v.grantedBy, 1);
+  assertEquals(v.queryConstrained, false);
+});
+
+Deno.test("AC-56.9 bis: le troisieme etat ne se declenche pas a tort", () => {
+  const constrained = entry([{ param: "status", values: [{ type: "any", value: "open" }] }]);
+
+  // Cas de l'enonce : le seul scope couvrant le chemin de test porte les filtres. La note
+  // due est celle de l'etat 2, et le troisieme etat n'a pas lieu d'etre.
+  const only = verdict([constrained], "/v1/items?status=open");
+  assertEquals(only.allowed, true);
+  assertEquals(only.queryConstrained, true);
+
+  // Cas que le troisieme etat ne doit PAS revendiquer : le scope contraignant vit ailleurs
+  // dans le blob, sur un autre chemin. Une note qui apparaitrait ici alarmerait sur un
+  // chemin que rien ne contraint, et serait ignoree en deux jours.
+  const elsewherePath: Scope[] = [
+    "GET:/v1/other",
+    { ...constrained, pattern: "/v1/items" } as ScopeEntry,
+  ];
+  const other = verdict(elsewherePath, "/v1/other?force=true");
+  assertEquals(other.allowed, true);
+  assertEquals(other.queryConstrained, false);
+  assertEquals(other.queryConstrainedElsewhere, false);
+
+  // Meme chemin, autre methode : le scope contraignant ne couvre pas cette requete non plus.
+  const elsewhereMethod: Scope[] = [
+    "POST:/v1/items",
+    { ...constrained, methods: ["GET"] } as ScopeEntry,
+  ];
+  const post = verdict(elsewhereMethod, "/v1/items?force=true", "POST");
+  assertEquals(post.allowed, true);
+  assertEquals(post.queryConstrainedElsewhere, false);
+
+  // Temoin : sur le chemin et la methode reellement couverts, le drapeau se leve bien.
+  assertEquals(
+    verdict(["GET:/v1/items", constrained], "/v1/items?force=true").queryConstrainedElsewhere,
+    true,
+  );
+});
+
+Deno.test("AC-54.6 bis: un queryFilters vide ne contraint rien a l'evaluation", () => {
+  // Le pendant matching d'AC-54.6, qui ne verifie que l'absence de bump de version. Un
+  // tableau vide traite comme un axe present declencherait le deni par defaut sur tous les
+  // parametres, alors qu'il est semantiquement identique a l'absence de l'axe.
+  const empty: ScopeEntry = { methods: ["GET"], pattern: "/v1/items", queryFilters: [] };
+  assertEquals(allowed([empty], "/v1/items?force=true&sort=asc"), true);
+  assertEquals(allowed([empty], "/v1/items"), true);
+  const v = verdict([empty], "/v1/items?force=true");
+  assertEquals(v.queryConstrained, false);
+});
+
 Deno.test("AC-51.16: les autres types d'ObjectValue fonctionnent sur une valeur de query", () => {
   const cases: [string, ObjectValue, string, string][] = [
     ["wildcard", { type: "wildcard" }, "n-importe-quoi", ""],

--- a/tests/testu/ui/logs-bundle.test.ts
+++ b/tests/testu/ui/logs-bundle.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "@std/assert";
+
+// src/ui/logs-client.ts touche au DOM et ne peut pas etre importe sous la config serveur qui
+// type-checke les tests : la verification passe par le bundle livre, comme AC-46.6. Ce
+// fichier exige donc un deno task build:client prealable.
+const BUNDLE = await Deno.readTextFile("static/logs-client.js");
+
+Deno.test("AC-57.6: SECURITE, la page /logs ne construit aucun noeud depuis une chaine", () => {
+  // Un nom de parametre est une chaine entierement controlee par l'appelant, qui traverse le
+  // serveur jusqu'au navigateur de l'auteur du blob : c'est le seul chemin d'injection ouvert
+  // par la decision de §14.6. Le rendu se fait par textContent, et la seule facon pour un
+  // « <img src=x onerror=...> » de devenir un noeud est qu'un innerHTML reapparaisse ici.
+  // Le marqueur tient parce qu'esbuild ne mangle pas les noms de proprietes du DOM.
+  assertEquals(
+    BUNDLE.includes("innerHTML"),
+    false,
+    "innerHTML est revenu dans le bundle /logs : un nom de parametre d'appelant peut " +
+      "redevenir du HTML dans la page de son auteur",
+  );
+  assertEquals(BUNDLE.includes("insertAdjacentHTML"), false);
+  assertEquals(BUNDLE.includes("outerHTML"), false);
+});
+
+Deno.test("AC-57.6 bis: TEMOIN, le bundle rend bien les noms de parametres", () => {
+  // Sans ce temoin, le test precedent resterait vert sur un bundle d'ou l'affichage des noms
+  // aurait entierement disparu : il ne prouverait plus rien de la surface qu'il protege.
+  assertEquals(
+    BUNDLE.includes("queryParamNames"),
+    true,
+    "l'affichage des noms de parametres a disparu du bundle /logs",
+  );
+  assertEquals(BUNDLE.includes("textContent"), true);
+});


### PR DESCRIPTION
Les tests de `queryFilters` existaient et passaient. Ce qu'on ne savait pas, c'est lesquels **mordent**. 19 mutations sur les gardes qui portent une propriété dont la perte serait invisible : 11 ont mordu, **8 sont passées sans qu'un seul des 828 tests bouge**.

Dans les huit cas la propriété est correctement implémentée dans `src/`. Ce sont des tests manquants ou qui visent à côté, aucun défaut de code. 828 à 844.

## La prise qui justifie l'audit à elle seule

**La query entière, valeurs comprises, pouvait entrer dans le champ `path` de l'entry `network`** sans qu'un test tombe. Cette entry vit en clair dans le ring buffer, contrairement au body `detailed` chiffré avec la clé client, et une query porte régulièrement un `?api_key=`.

Toute la série AC-57 reposait sur un test qui exerce l'extraction des noms **en isolation**. Par construction, une fuite qui entre par un autre champ de l'entry lui échappe. Le test livré sérialise l'entry complète et y cherche les secrets.

## Les sept autres

**Le plancher de version n'était gardé qu'au déchiffrement.** Le `Math.max` de la génération n'était couvert par rien sur le seul cas où une échelle et un maximum divergent, deux axes à la fois. Sous mutation, un blob à auth structurée plus `queryFilters` sort en `v: 4` et son propre déchiffrement le refuse : un blob mort livré avec un bandeau vert, et un 401 qui envoie son porteur vérifier une clé qui est bonne.

**L'additivité ne tenait que dans un ordre.** Partager la mémoïsation de l'axe query entre `ScopeEntry` fait resservir le refus du premier scope contraint à tous les suivants. AC-51.15 ne l'attrape pas : sa fixture met un scope string en premier, qui sort de la boucle avant que l'axe query soit atteint. Le test visait juste pour ce qu'il énonce, sa forme ne pouvait structurellement pas exercer le partage.

**AC-54.6 énonçait deux choses et n'en testait qu'une.** Un `queryFilters: []` traité comme un axe présent refuse tout paramètre, personne ne tombait.

**Trois trous côté logs.** Le plafond de 32 noms n'existait pour personne, une requête sans query pouvait produire un nom vide qui se lit comme un paramètre réellement envoyé, et surtout **le rendu des noms dans `/logs` n'était gardé par rien** : remplacer le `textContent` par un `innerHTML` passait sans qu'un test bouge, alors que c'est le seul chemin d'injection ouvert par la capture des noms de paramètres.

**Le troisième état du testeur pouvait se déclencher à tort** sans que personne tombe, ses critères n'étant couverts que du côté copy, qui vérifie la présence des chaînes et pas la condition qui les déclenche.

## Une garde qui tenait par un fil

Amputer de sa query le chemin que le proxy soumet à `checkRequestAccess` ne faisait tomber qu'un seul test, et il vient du lot de sécurité, aucun de la série v5. **AC-56.10 restait vert pour la mauvaise raison** : son unique filtre porte `required: true`, donc toute requête dont la query n'atteint pas le contrôle est refusée de toute façon et le 403 attendu tombe sans rien prouver du déni par défaut.

Le test n'est pas touché, il fait correctement son travail sur ce qu'il énonce, la généricité du message. Un cas jumeau à filtre non requis est ajouté pour que la seule cause de refus possible soit le paramètre non déclaré.

## Ce qui tient

Les deux points sur lesquels je voulais une réponse nette l'ont eue. La restriction de `any` attrape bien l'inversion et pas seulement le message de validation, et sa propagation en profondeur est gardée pour elle-même. Les schémas stricts gardent deux propriétés distinctes, perdre le `.strict()` et faire disparaître `queryFilters` de la valeur parsée, et chacune a son test sans que l'un couvre l'autre.

Le déni par défaut et les paliers d'occurrences tiennent. Le palier local au filtre en particulier : le rendre global au `ScopeEntry`, contaminé par un filtre voisin portant une regex, fait tomber un test et un seul.

## Un critère corrigé

AC-56.9 bis disait que la note ne doit pas apparaître « dès qu'un scope **non** contraignant existe ailleurs dans le blob ». C'est l'inverse du mécanisme et ça rendait l'énoncé auto-contradictoire.

## Périmètre

Les tests de copy et de gabarit n'ont pas été mutés, délibérément : s'ils cassent, ça se voit. Le tableau de couverture v5 reste à 86 sur 86, mais il est annoté : c'est de la couverture, pas de la morsure ligne à ligne.

`deno task verify` vert, 844 tests, 0 échec. `src/` n'est pas touché.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the acceptance criteria for query-constraint reporting.
  - Added clarification for cases where a constraining scope does not cover the requested path or method.
  - Updated coverage documentation to reflect the completed v5 audit and expanded test coverage.

- **Tests**
  - Added coverage for query parameter capture, filtering, counting, truncation, and default-deny behavior.
  - Added validation for additive scopes, constraint reporting, and safe `/logs` bundle rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->