### PR TITLE
feat(api): passe en zod-openapi 1.6.3 et distingue le format du contenu

### DIFF
--- a/ACTIVITY.md
+++ b/ACTIVITY.md
@@ -303,3 +303,18 @@
   - Recette manuelle du mode Scalingo Database API sur un vrai compte, condition d'entrée du multi-addon
   - Auto-hébergement des assets Swagger dans `/static/` pour supprimer la CSP dédiée de `/api/docs`
   - Tests e2e toujours reportés
+
+## 2026-09-06 : @hono/zod-openapi 1.6.3, 415 unsupported_media_type sur /api/*
+
+- **Changements** :
+  - Montée de version `@hono/zod-openapi` 1.6.2 → 1.6.3 : un `Content-Type` absent ou différent de `application/json` sur une route `/api/*` à corps est désormais refusé en `415 unsupported_media_type`, avant toute lecture du corps. Sept routes concernées : `generate`, `decode`, `share/encode`, `share/decode`, `list-apps`, `list-addons`, `test-proxy`. `GET /api/salt` n'a pas de corps et n'est jamais concernée.
+  - Le 400 `invalid_body` reste inchangé et distinct : il signale un JSON lu puis rejeté par le schéma, quand le 415 signale un format illisible avant toute lecture. Avant ce changement les deux cas tombaient dans le même 400.
+  - Les sept routes déclarent le 415 dans l'OpenAPI servi, un test dérive la parité entre la déclaration et le comportement réel plutôt que de la coder en dur.
+  - Documentation : specs (§8.3), critères d'acceptation (AC-47.11, AC-47.12) et changelog mis à jour.
+- **Décisions** :
+  - Le 415 n'a pas été ajouté à la liste des codes d'erreur de la route proxy dans `/llms.txt` ni au panneau Doc de l'UI. Ces deux surfaces documentent exclusivement les erreurs reçues en consommant une URL FGP (`/{blob}/*`) ; le 415 est une erreur des endpoints internes `/api/*`, jamais atteignable via le formulaire puisque le client JS de l'UI pose toujours `Content-Type: application/json`. L'y ajouter aurait été factuellement faux et aurait cassé le test de parité qui compte 15 codes proxy dans `/llms.txt`. Une note informative hors de cette liste a été proposée pour `/llms.txt`, à intégrer par le dev.
+- **Process** :
+  - Session reprise après l'interruption réseau d'un agent précédent en plein milieu de la tâche : le code (bump de version, schémas OpenAPI, tests) était déjà livré et vérifié, seule la documentation restait à faire.
+- **Prochaines étapes** :
+  - Intégrer la note `/llms.txt` proposée par le PO (texte et emplacement fournis, hors de la liste des codes de la route proxy)
+  - Lancer `deno task build` (ou au moins `build:changelog`) avant déploiement pour propager la nouvelle entrée de changelog dans l'UI

--- a/ACTIVITY.md
+++ b/ACTIVITY.md
@@ -312,9 +312,8 @@
   - Les sept routes déclarent le 415 dans l'OpenAPI servi, un test dérive la parité entre la déclaration et le comportement réel plutôt que de la coder en dur.
   - Documentation : specs (§8.3), critères d'acceptation (AC-47.11, AC-47.12) et changelog mis à jour.
 - **Décisions** :
-  - Le 415 n'a pas été ajouté à la liste des codes d'erreur de la route proxy dans `/llms.txt` ni au panneau Doc de l'UI. Ces deux surfaces documentent exclusivement les erreurs reçues en consommant une URL FGP (`/{blob}/*`) ; le 415 est une erreur des endpoints internes `/api/*`, jamais atteignable via le formulaire puisque le client JS de l'UI pose toujours `Content-Type: application/json`. L'y ajouter aurait été factuellement faux et aurait cassé le test de parité qui compte 15 codes proxy dans `/llms.txt`. Une note informative hors de cette liste a été proposée pour `/llms.txt`, à intégrer par le dev.
+  - Le 415 n'a pas été ajouté à la liste des codes d'erreur de la route proxy dans `/llms.txt` ni au panneau Doc de l'UI. Ces deux surfaces documentent exclusivement les erreurs reçues en consommant une URL FGP (`/{blob}/*`) ; le 415 est une erreur des endpoints internes `/api/*`, jamais atteignable via le formulaire puisque le client JS de l'UI pose toujours `Content-Type: application/json`. L'y ajouter aurait été factuellement faux et aurait cassé le test de parité qui compte 15 codes proxy dans `/llms.txt`. Une note informative a été ajoutée à `/llms.txt` hors de cette liste, à destination d'un agent qui construit lui-même une requête vers `/api/generate`.
 - **Process** :
   - Session reprise après l'interruption réseau d'un agent précédent en plein milieu de la tâche : le code (bump de version, schémas OpenAPI, tests) était déjà livré et vérifié, seule la documentation restait à faire.
 - **Prochaines étapes** :
-  - Intégrer la note `/llms.txt` proposée par le PO (texte et emplacement fournis, hors de la liste des codes de la route proxy)
   - Lancer `deno task build` (ou au moins `build:changelog`) avant déploiement pour propager la nouvelle entrée de changelog dans l'UI

--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,7 @@
     "hono": "npm:hono@^4.13.5",
     "@hono/swagger-ui": "npm:@hono/swagger-ui@^0.6.1",
     "zod": "npm:zod@^4.5.4",
-    "@hono/zod-openapi": "npm:@hono/zod-openapi@1.6.2",
+    "@hono/zod-openapi": "npm:@hono/zod-openapi@1.6.3",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/encoding": "jsr:@std/encoding@^1.0.11"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -5,11 +5,11 @@
     "jsr:@std/encoding@^1.0.11": "1.0.11",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.6": "1.0.9",
-    "npm:@hono/swagger-ui@~0.6.1": "0.6.1_hono@4.13.5",
-    "npm:@hono/zod-openapi@1.6.2": "1.6.2_hono@4.13.5_zod@4.5.4",
+    "npm:@hono/swagger-ui@~0.6.1": "0.6.1_hono@4.13.7",
+    "npm:@hono/zod-openapi@1.6.3": "1.6.3_hono@4.13.7_zod@4.5.4",
     "npm:concurrently@*": "9.2.1",
     "npm:esbuild@*": "0.28.0",
-    "npm:hono@^4.13.5": "4.13.5",
+    "npm:hono@^4.13.5": "4.13.7",
     "npm:tailwindcss@3": "3.4.17_postcss@8.5.3",
     "npm:zod@^4.5.4": "4.5.4"
   },
@@ -180,14 +180,14 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@hono/swagger-ui@0.6.1_hono@4.13.5": {
+    "@hono/swagger-ui@0.6.1_hono@4.13.7": {
       "integrity": "sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ==",
       "dependencies": [
         "hono"
       ]
     },
-    "@hono/zod-openapi@1.6.2_hono@4.13.5_zod@4.5.4": {
-      "integrity": "sha512-ktnBqVgvIlopiiB9ab6hqoYefhcb0DUZU5QJ1F5UtDu8w6+cIORENz93sTZT6G0mQNes0/TbbadfrOpdehioPA==",
+    "@hono/zod-openapi@1.6.3_hono@4.13.7_zod@4.5.4": {
+      "integrity": "sha512-VYR82Y60plu8g3pN60OUXMVKpmxh3R04Qs++3DY9vtwZ9/sA/BRY0PcRIR+Z37/3itWtM7pYwT9bKiH9JhqV6Q==",
       "dependencies": [
         "@asteasolutions/zod-to-openapi",
         "@hono/zod-validator",
@@ -196,7 +196,7 @@
         "zod"
       ]
     },
-    "@hono/zod-validator@0.9.1_hono@4.13.5_zod@4.5.4": {
+    "@hono/zod-validator@0.9.1_hono@4.13.7_zod@4.5.4": {
       "integrity": "sha512-iiv6w0qrIc0arfvCtUqBWsvl4fXjzaTcQcCJTTtCnkawF9HHGE+KjEl0ox3gQJ6rKZEgE3mLExlQCF72M+mNuw==",
       "dependencies": [
         "hono",
@@ -498,8 +498,8 @@
         "function-bind"
       ]
     },
-    "hono@4.13.5": {
-      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="
+    "hono@4.13.7": {
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="
     },
     "is-binary-path@2.1.0": {
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
@@ -908,7 +908,7 @@
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/encoding@^1.0.11",
       "npm:@hono/swagger-ui@~0.6.1",
-      "npm:@hono/zod-openapi@1.6.2",
+      "npm:@hono/zod-openapi@1.6.3",
       "npm:hono@^4.13.5",
       "npm:zod@^4.5.4"
     ]

--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -3188,6 +3188,18 @@ Le ciphertext d'un blob vaut au plus 3 044 octets, donc 128 Ko autorise un ratio
 **When** on inspecte la reponse
 **Then** elle porte `X-FGP-Source: proxy` et la shape `{error, message}`. Le proxy transparent n'est pas entame : ces codes sont produits par FGP et se declarent comme tels
 
+### AC-47.11 Parite OpenAPI/comportement reel pour le 415 unsupported_media_type
+
+**Given** les sept routes `/api/*` qui acceptent un corps (`generate`, `decode`, `share/encode`, `share/decode`, `list-apps`, `list-addons`, `test-proxy`)
+**When** on compare, pour chaque operation, le `415 unsupported_media_type` declare dans l'OpenAPI genere au comportement reel obtenu en appelant la route sans Content-Type JSON
+**Then** les deux coincident exactement : aucune operation ne declare le code sans le servir, aucune ne le sert sans le declarer. `GET /api/salt` n'a pas de corps, elle ne declare et ne sert jamais ce code
+
+### AC-47.12 Un Content-Type JSON valide laisse juger le corps, pas le format
+
+**Given** une requete `POST /api/generate` avec `Content-Type: application/json` et un corps JSON syntaxiquement valide mais qui ne satisfait pas le schema attendu (champs requis manquants)
+**When** la requete est traitee
+**Then** la reponse est `400 invalid_body`, jamais `415`. Le controle de type de media ne regarde que l'en-tete `Content-Type`, jamais le contenu : une fois le format accepte, tout refus qui suit porte sur le contenu, pas sur le format. C'est la frontiere que ce changement introduit, `415` dit qu'on ne sait pas lire ce format, `400 invalid_body` dit que le JSON a ete lu et qu'il ne convient pas
+
 ---
 
 ## AC-48 : Dialecte regex, ancrage et budgets de denombrement

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6 septembre 2026
+
+- **Breaking** : un appel `/api/*` sans `Content-Type: application/json` renvoie désormais `415 unsupported_media_type` au lieu de `400`. Posez l'en-tête pour corriger
+
 ## 4 septembre 2026
 
 - **Breaking** : `POST /api/test-scope` est supprimé. L'interface testait déjà les scopes dans le navigateur, la route serveur n'avait aucun appelant

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -650,13 +650,16 @@ Les endpoints internes du proxy qui tapent eux-mêmes des APIs externes (ex : `P
 - Échec réseau (fetch throw) → 502 `upstream_unreachable` + `X-FGP-Source: proxy`.
 - Échec d'exchange token (pour `list-apps` et `list-addons`) → 401 `token_exchange_failed` + `X-FGP-Source: proxy`.
 
-Trois codes supplémentaires apparaissent sur ces endpoints. Les deux premiers leur sont propres, ils n'existent pas sur la route proxy. Le troisième vit sur les deux surfaces, avec un plafond différent de chaque côté (§18.5) :
+Quatre codes supplémentaires apparaissent sur ces endpoints. Trois leur sont propres, ils n'existent pas sur la route proxy. `payload_too_large` vit sur les deux surfaces, avec un plafond différent de chaque côté (§18.5) :
 
 | Status | Code | Endpoint | Condition |
 |--------|------|----------|-----------|
 | 400 | `invalid_target` | `/api/generate`, `/api/list-apps`, `/api/list-addons` | La cible ne respecte pas la forme exigée, ou son hôte n'est pas public (ADR-0009) |
 | 400 | `invalid_scope` | `/api/generate` | Un pattern de scope porte un `?` : le pattern ne porte jamais la query, qui se contraint via `queryFilters` (cf. §19) |
+| 415 | `unsupported_media_type` | Les sept routes `/api/*` qui acceptent un corps (`generate`, `decode`, `share/encode`, `share/decode`, `list-apps`, `list-addons`, `test-proxy`) | Le `Content-Type` de la requête n'est pas `application/json`, ou est absent : posez cet en-tête, la requête est refusée avant même la lecture du corps. `GET /api/salt` n'a pas de corps et n'est jamais concernée |
 | 413 | `payload_too_large` | tout `/api/*` | Corps de requête au-delà du plafond de la route |
+
+`unsupported_media_type` est volontairement distinct de `invalid_body`, qui reste inchangé. Le premier dit que FGP n'a pas su lire le format du corps, avant même d'y regarder. Le second dit que le corps a été lu et que son contenu ne convient pas. Avant, les deux tombaient dans le même 400 et un appelant ne pouvait pas savoir s'il devait corriger son en-tête ou son contenu ; il le sait désormais. **C'est un changement cassant** : un appelant qui envoyait du JSON sans poser `Content-Type: application/json` recevait 400 et reçoit désormais 415. La remédiation tient en une ligne, poser l'en-tête.
 
 Ne pas confondre `token_exchange_failed` (401, endpoints internes `/api/list-apps` et `/api/list-addons`) avec `auth_exchange_failed` (502, proxy principal en mode `scalingo-exchange`). Les deux décrivent un échange de token Scalingo qui a échoué, mais ils ne s'adressent pas au même public : le premier dit à l'utilisateur de l'UI que **son** token est mauvais, au moment où il le saisit, et il peut le corriger. Le second dit au consommateur d'une URL FGP que le proxy n'a pas pu s'authentifier pour lui, ce qui n'est pas de son ressort et ne se corrige pas côté client. Deux publics, deux statuts, deux codes.
 

--- a/src/routes/llms.ts
+++ b/src/routes/llms.ts
@@ -142,6 +142,11 @@ once and never stored: losing it makes the blob unusable. An optional \`key\` fi
 in the request lets a caller supply its own client key, 24 to 256 printable ASCII
 characters without spaces.
 
+Every \`/api/*\` request that carries a body must set \`Content-Type: application/json\`.
+Anything else is rejected with 415 \`unsupported_media_type\` before the body is even
+read, a different signal from 400 \`invalid_body\`: 415 means the format itself could
+not be read, 400 means the JSON was read and rejected.
+
 Calling through the proxy, blob in the URL then blob in a header (recommended):
 
 \`\`\`

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -123,6 +123,19 @@ const payloadTooLargeResponse = {
   content: { "application/json": { schema: PayloadTooLargeErrorSchema } },
 };
 
+// Meme situation que le 413 : produit par le controle de type de media de
+// @hono/zod-openapi et non par un handler, donc invisible de createRoute. Distinct de
+// invalid_body, qui reste le code du corps mal forme une fois le type accepte.
+const UnsupportedMediaTypeErrorSchema = errorSchema(
+  ["unsupported_media_type"],
+  "UnsupportedMediaTypeError",
+);
+
+const unsupportedMediaTypeResponse = {
+  description: "Content-Type is absent or is not application/json",
+  content: { "application/json": { schema: UnsupportedMediaTypeErrorSchema } },
+};
+
 const ObjectValueSchema = z.union([
   z.object({ type: z.literal("any"), value: z.unknown() }),
   z.object({ type: z.literal("wildcard") }),
@@ -417,6 +430,7 @@ const decodeRoute = createRoute({
       content: { "application/json": { schema: DecodeError401Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
     500: {
       description: "Server misconfigured (FGP_SALT missing)",
       content: { "application/json": { schema: DecodeError500Schema } },
@@ -447,6 +461,7 @@ const shareEncodeRoute = createRoute({
       content: { "application/json": { schema: ShareEncodeError400Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
   },
 });
 
@@ -472,6 +487,7 @@ const shareDecodeRoute = createRoute({
       content: { "application/json": { schema: ShareDecodeError400Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
   },
 });
 
@@ -513,6 +529,7 @@ const generateRoute = createRoute({
       content: { "application/json": { schema: GenerateError400Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
     500: {
       description: "Server misconfigured (FGP_SALT missing)",
       content: { "application/json": { schema: GenerateError500Schema } },
@@ -546,6 +563,7 @@ const listAppsRoute = createRoute({
       content: { "application/json": { schema: ListAppsError401Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
     502: {
       description:
         "Scalingo API unreachable (fetch throw) or returned a non-ok status when listing apps",
@@ -585,6 +603,7 @@ const listAddonsRoute = createRoute({
       content: { "application/json": { schema: ListAddonsError404Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
     502: {
       description:
         "Scalingo API unreachable (fetch throw) or returned a non-ok status when listing addons",
@@ -616,6 +635,7 @@ const testProxyRoute = createRoute({
       content: { "application/json": { schema: TestProxyError400Schema } },
     },
     413: payloadTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
   },
 });
 

--- a/tests/testi/api.test.ts
+++ b/tests/testi/api.test.ts
@@ -139,16 +139,20 @@ Deno.test({
 });
 
 Deno.test({
-  name: "POST /api/generate with no JSON body returns 400",
+  name: "POST /api/generate sans Content-Type JSON renvoie 415 unsupported_media_type",
   fn: async () => {
     setup();
 
+    // Sans Content-Type, le controle de type de media refuse avant toute lecture du corps.
+    // Le code distingue « je ne sais pas lire ce format » de « ce JSON ne convient pas »,
+    // que 400 invalid_body continue de porter.
     const res = await app.request("/api/generate", {
       method: "POST",
       body: "not json",
     });
 
-    assertEquals(res.status, 400);
+    assertEquals(res.status, 415);
+    assertEquals((await res.json()).error, "unsupported_media_type");
 
     teardown();
   },
@@ -234,16 +238,20 @@ Deno.test({
 });
 
 Deno.test({
-  name: "POST /api/list-apps with no body returns 400",
+  name: "POST /api/list-apps sans Content-Type JSON renvoie 415 unsupported_media_type",
   fn: async () => {
     setup();
 
+    // Sans Content-Type, le controle de type de media refuse avant toute lecture du corps.
+    // Le code distingue « je ne sais pas lire ce format » de « ce JSON ne convient pas »,
+    // que 400 invalid_body continue de porter.
     const res = await app.request("/api/list-apps", {
       method: "POST",
       body: "not json",
     });
 
-    assertEquals(res.status, 400);
+    assertEquals(res.status, 415);
+    assertEquals((await res.json()).error, "unsupported_media_type");
 
     teardown();
   },

--- a/tests/testi/api.test.ts
+++ b/tests/testi/api.test.ts
@@ -143,16 +143,21 @@ Deno.test({
   fn: async () => {
     setup();
 
-    // Sans Content-Type, le controle de type de media refuse avant toute lecture du corps.
-    // Le code distingue « je ne sais pas lire ce format » de « ce JSON ne convient pas »,
-    // que 400 invalid_body continue de porter.
-    const res = await app.request("/api/generate", {
-      method: "POST",
-      body: "not json",
-    });
-
-    assertEquals(res.status, 415);
-    assertEquals((await res.json()).error, "unsupported_media_type");
+    // Deux facons de ne pas etre du JSON, et il faut les deux : un corps en chaine fait
+    // poser text/plain par le constructeur de Request, donc il n'exerce que l'en-tete
+    // ERRONE. Seul un corps en octets laisse l'en-tete reellement ABSENT.
+    // Le controle refuse avant toute lecture du corps, et le code distingue « je ne sais
+    // pas lire ce format » de « ce JSON ne convient pas », que 400 invalid_body porte.
+    for (
+      const [label, init] of [
+        ["en-tete absent", { method: "POST", body: new Uint8Array([1, 2, 3]) }],
+        ["en-tete errone", { method: "POST", body: "not json" }],
+      ] as [string, RequestInit][]
+    ) {
+      const res = await app.request("/api/generate", init);
+      assertEquals(res.status, 415, label);
+      assertEquals((await res.json()).error, "unsupported_media_type", label);
+    }
 
     teardown();
   },
@@ -242,16 +247,18 @@ Deno.test({
   fn: async () => {
     setup();
 
-    // Sans Content-Type, le controle de type de media refuse avant toute lecture du corps.
-    // Le code distingue « je ne sais pas lire ce format » de « ce JSON ne convient pas »,
-    // que 400 invalid_body continue de porter.
-    const res = await app.request("/api/list-apps", {
-      method: "POST",
-      body: "not json",
-    });
-
-    assertEquals(res.status, 415);
-    assertEquals((await res.json()).error, "unsupported_media_type");
+    // Meme couple de cas que sur /api/generate : un corps en chaine fait poser text/plain,
+    // seul un corps en octets laisse l'en-tete absent.
+    for (
+      const [label, init] of [
+        ["en-tete absent", { method: "POST", body: new Uint8Array([1, 2, 3]) }],
+        ["en-tete errone", { method: "POST", body: "not json" }],
+      ] as [string, RequestInit][]
+    ) {
+      const res = await app.request("/api/list-apps", init);
+      assertEquals(res.status, 415, label);
+      assertEquals((await res.json()).error, "unsupported_media_type", label);
+    }
 
     teardown();
   },

--- a/tests/testi/openapi-body-limit.test.ts
+++ b/tests/testi/openapi-body-limit.test.ts
@@ -199,9 +199,13 @@ Deno.test({
 // --- Le 415 du controle de type de media suit la meme regle de parite que le 413 ---
 
 async function servesUnsupportedMediaType(path: string, method: string): Promise<boolean> {
-  // Aucun Content-Type : c'est la condition exacte que le controle refuse, et elle est
-  // independante du corps envoye.
-  const res = await app.request(path, { method: method.toUpperCase(), body: "not json" });
+  // Corps en octets et non en chaine : une chaine fait poser text/plain par le constructeur
+  // de Request, ce qui exercerait l'en-tete errone au lieu de l'en-tete absent. Les deux
+  // sont refuses, mais la parite doit se mesurer sur la condition qu'elle annonce.
+  const res = await app.request(path, {
+    method: method.toUpperCase(),
+    body: new Uint8Array([1, 2, 3]),
+  });
   const raw = await res.text();
   if (res.status !== 415) return false;
   try {

--- a/tests/testi/openapi-body-limit.test.ts
+++ b/tests/testi/openapi-body-limit.test.ts
@@ -195,3 +195,94 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+// --- Le 415 du controle de type de media suit la meme regle de parite que le 413 ---
+
+async function servesUnsupportedMediaType(path: string, method: string): Promise<boolean> {
+  // Aucun Content-Type : c'est la condition exacte que le controle refuse, et elle est
+  // independante du corps envoye.
+  const res = await app.request(path, { method: method.toUpperCase(), body: "not json" });
+  const raw = await res.text();
+  if (res.status !== 415) return false;
+  try {
+    return (JSON.parse(raw) as { error?: string }).error === "unsupported_media_type";
+  } catch {
+    return false;
+  }
+}
+
+Deno.test({
+  name:
+    "AC-47.11: PARITE, une operation OpenAPI declare 415 unsupported_media_type si et seulement si elle le sert",
+  fn: async () => {
+    setup();
+    try {
+      const spec = await loadSpec();
+      const operations = operationsOf(spec);
+      assertNotEquals(operations.length, 0, "aucune operation enumeree, le test ne verifie rien");
+
+      const undeclared: string[] = [];
+      const overdeclared: string[] = [];
+      let probed = 0;
+
+      for (const { path, method, operation } of operations) {
+        const declares = declaredErrorCodes(spec, operation, "415").includes(
+          "unsupported_media_type",
+        );
+
+        // Sans corps documente, il n'y a aucun type de media a contrarier : le controle ne
+        // se declenche pas et declarer le code documenterait une reponse inatteignable.
+        if (!operation.requestBody) {
+          if (declares) overdeclared.push(`${method.toUpperCase()} ${path} (sans corps)`);
+          continue;
+        }
+
+        probed++;
+        const serves = await servesUnsupportedMediaType(path, method);
+        if (serves && !declares) undeclared.push(`${method.toUpperCase()} ${path}`);
+        if (!serves && declares) overdeclared.push(`${method.toUpperCase()} ${path}`);
+      }
+
+      assertNotEquals(probed, 0, "aucune operation sondee, le test ne verifie rien");
+
+      assertEquals(
+        undeclared,
+        [],
+        `415 unsupported_media_type servi mais absent de l'enum OpenAPI : ${undeclared.join(", ")}`,
+      );
+      assertEquals(
+        overdeclared,
+        [],
+        `415 unsupported_media_type declare mais jamais servi : ${overdeclared.join(", ")}`,
+      );
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "AC-47.12: un Content-Type JSON valide ne declenche pas le 415, le corps est juge",
+  fn: async () => {
+    setup();
+    try {
+      // La frontiere entre les deux codes est le seul point que le changement de contrat
+      // rend delicat : 415 dit « je ne sais pas lire ce format », 400 dit « ce JSON ne
+      // convient pas ». Les confondre reviendrait a rendre le diagnostic inutile.
+      const res = await app.request("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+
+      assertEquals(res.status, 400);
+      assertEquals((await res.json()).error, "invalid_body");
+    } finally {
+      teardown();
+    }
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Le lot précédent avait épinglé `@hono/zod-openapi` à 1.6.2 pour débloquer la CI sans emporter un changement de contrat en douce. Il est maintenant pris délibérément.

## Ce que la 1.6.3 change

Une requête vers une route `/api/*` dont le `Content-Type` n'est pas `application/json` est refusée **avant toute lecture du corps**, avec un 415 et le code `unsupported_media_type`.

## Pourquoi monter plutôt que rester épinglé

Parce que **415 et 400 ne disent plus la même chose**. Le 415 dit « je ne sais pas lire ce format ». Le 400 `invalid_body`, qui existe toujours et ne bouge pas, dit « j'ai lu ton JSON et il ne convient pas ».

Avant, les deux tombaient dans le même 400 et un appelant ne pouvait pas savoir s'il devait corriger son en-tête ou son contenu. C'est un gain de diagnostic réel, pas une régression subie.

**Changement cassant** : un appelant qui envoyait du JSON sans poser l'en-tête recevait 400 et reçoit maintenant 415. La remédiation tient en une ligne, poser `Content-Type: application/json`.

## Le contrat

Les sept routes qui portent un corps déclarent le 415 dans la spec servie : `/api/generate`, `/api/decode`, `/api/share/encode`, `/api/share/decode`, `/api/list-apps`, `/api/list-addons` et `/api/test-proxy`. Les sept ont été vérifiées une par une, et un test dérive la parité du comportement réel plutôt que d'une liste écrite à la main, sur le modèle déjà utilisé pour le 413.

`GET /api/salt` en est exclue à dessein : elle n'a pas de corps.

## Un arbitrage de périmètre, contre ma demande initiale

J'avais demandé d'ajouter ce code au panneau Doc et à `/llms.txt`. Le PO a refusé, et il a eu raison.

Les deux surfaces se déclarent explicitement sur les erreurs reçues **en consommant** une URL FGP, c'est-à-dire la route proxy `/{blob}/*`. `unsupported_media_type` n'y arrive jamais : c'est une erreur des endpoints internes, et le client de l'interface pose toujours l'en-tête lui-même. C'est exactement la même famille qu'`invalid_target` et `invalid_scope`, absents de ces deux surfaces pour la même raison.

L'y ajouter aurait cassé le test de parité à quinze codes, et surtout raconté un mensonge de périmètre. `/llms.txt` gagne à la place une note isolée, hors du bloc compté, utile à un agent qui construit sa propre requête de génération en curl.

## Vérification

`deno task verify` vert, 850 tests, 0 échec. `deno install --frozen` en sortie 0. `/llms.txt` pèse 8364 octets pour un plafond de 16384.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Requests to JSON-based API endpoints without `Content-Type: application/json` now return `415 unsupported_media_type`.
  - Clients sending JSON must include the `Content-Type: application/json` header.

- **Bug Fixes**
  - Properly distinguishes unsupported request formats (`415`) from invalid JSON or schema content (`400 invalid_body`).

- **Documentation**
  - Updated API specifications, changelog, and usage guidance to document the new request-header requirement and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->